### PR TITLE
Get reflected values from the DeploymentPropertiesExtended object

### DIFF
--- a/arm-helper/README.md
+++ b/arm-helper/README.md
@@ -96,14 +96,15 @@ import arm from "./arm.json"
 
 export class MyIngredient extends BaseIngredient {
 
-  public async Execute(): Promise<void> {
+  public async Execute(): Promise<Any> {
 
     const util = IngredientManager.getIngredientFunction("coreutils", this._ctx)
+    let result: any[] = [];
     const helper = new ARMHelper(this._ctx)
 
     const parameters = helper.BakeParamsToARMParams(this._name, this._ingredient.properties.parameters)
-
-    await helper.DeployTemplate(this._name, arm, parameters, util.resource_group())
+    result.push( await helper.DeployTemplate(this._name, arm, parameters, util.resource_group()) )
+    return result
   }
 }
 

--- a/arm-helper/src/arm-helper.ts
+++ b/arm-helper/src/arm-helper.ts
@@ -1,6 +1,6 @@
 import { IIngredient, Logger, DeploymentContext, BakeVariable } from '@azbake/core';
 import { ResourceManagementClient } from '@azure/arm-resources';
-import { Deployment, DeploymentProperties, DeploymentPropertiesExtended } from '@azure/arm-resources/esm/models';
+import { Deployment, DeploymentProperties } from '@azure/arm-resources/esm/models';
 import { DeploymentPropertiesExtended } from '@azure/arm-resources/esm/models/mappers';
 
 export class ARMHelper {

--- a/arm-helper/src/arm-helper.ts
+++ b/arm-helper/src/arm-helper.ts
@@ -1,6 +1,7 @@
 import { IIngredient, Logger, DeploymentContext, BakeVariable } from '@azbake/core';
 import { ResourceManagementClient } from '@azure/arm-resources';
-import { Deployment, DeploymentProperties } from '@azure/arm-resources/esm/models';
+import { Deployment, DeploymentProperties, DeploymentPropertiesExtended } from '@azure/arm-resources/esm/models';
+import { DeploymentPropertiesExtended } from '@azure/arm-resources/esm/models/mappers';
 
 export class ARMHelper {
 
@@ -12,7 +13,7 @@ export class ARMHelper {
     _ctx: DeploymentContext;
     _ingredient: IIngredient;
 
-    public async DeployTemplate(deploymentName: string, template: any, params: any, resourceGroup: string): Promise<void> {
+    public async DeployTemplate(deploymentName: string, template: any, params: any, resourceGroup: string): Promise<DeploymentPropertiesExtended> {
         
         const logger = new Logger(this._ctx.Logger.getPre().concat(deploymentName));
 
@@ -52,12 +53,13 @@ export class ARMHelper {
                 throw new Error('validate failed');
             }
             logger.log('starting deployment...');
-            let result = await client.deployments.createOrUpdate(resourceGroup, deploymentName, deployment);
+            let result = await client.deployments.createOrUpdate(resourceGroup, deploymentName, deployment) 
             if (result._response.status > 299) {
                 throw new Error(`ARM Error ${result._response.bodyAsText}`);
             }
 
             logger.log('deployment finished...');
+            return ( result.properties || <DeploymentPropertiesExtended>{} )
 
         } catch(error) {
             logger.error('deployment failed: ' + error);

--- a/arm-helper/src/arm-helper.ts
+++ b/arm-helper/src/arm-helper.ts
@@ -13,7 +13,7 @@ export class ARMHelper {
     _ctx: DeploymentContext;
     _ingredient: IIngredient;
 
-    public async DeployTemplate(deploymentName: string, template: any, params: any, resourceGroup: string): Promise<DeploymentPropertiesExtended> {
+    public async DeployTemplate(deploymentName: string, template: any, params: any, resourceGroup: string): Promise<any> {
         
         const logger = new Logger(this._ctx.Logger.getPre().concat(deploymentName));
 
@@ -59,7 +59,7 @@ export class ARMHelper {
             }
 
             logger.log('deployment finished...');
-            return ( result.properties || <DeploymentPropertiesExtended>{} )
+            return result.properties
 
         } catch(error) {
             logger.error('deployment failed: ' + error);

--- a/ingredient-template/README.md
+++ b/ingredient-template/README.md
@@ -48,7 +48,7 @@ let source: string = this._ingredient.properties.source.value(this._ctx)
 A plugin ingredient must extend `BaseIngredient` from "@azbake/core". It must also implement: 
 
 ```javascript
-public async Execute(): Promise<void>{}
+public async Execute(): Promise<any>{}
 ```
 
 Within your execute method you have access to the current deployment context, which implements `DeploymentContext` from "@azbake/core"

--- a/ingredient-template/create-ingredient-quickstart.md
+++ b/ingredient-template/create-ingredient-quickstart.md
@@ -15,9 +15,10 @@ import { ARMHelper } from "@azbake/arm-helper"
 import ARMTemplate from "./arm.json"
 	
 export class MyCustomPlugin extends BaseIngredient {
-    public async Execute(): Promise<void> {
+    public async Execute(): Promise<any> {
 		try {
             let util = IngredientManager.getIngredientFunction("coreutils", this._ctx)
+            let result: any[] = [];
             this._logger.log('Custom Plugin Logging: ' + this._ingredient.properties.source)
             
             const helper = new ARMHelper(this._ctx);
@@ -25,7 +26,8 @@ export class MyCustomPlugin extends BaseIngredient {
             let params:any={}
             params["parameterName1"]="parameterValue1"
             params["parameterName2"]="parameterValue2"
-            let result = await helper.DeployTemplate(this._name, ARMTemplate, params, util.resource_group())
+            result.push( await helper.DeployTemplate(this._name, ARMTemplate, params, util.resource_group()) )
+            return result
             
         } catch(error){
             this._logger.error('deployment failed: ' + error)

--- a/ingredient-template/create-ingredient-quickstart.md
+++ b/ingredient-template/create-ingredient-quickstart.md
@@ -25,7 +25,7 @@ export class MyCustomPlugin extends BaseIngredient {
             let params:any={}
             params["parameterName1"]="parameterValue1"
             params["parameterName2"]="parameterValue2"
-            await helper.DeployTemplate(this._name, ARMTemplate, params, util.resource_group())
+            let result = await helper.DeployTemplate(this._name, ARMTemplate, params, util.resource_group())
             
         } catch(error){
             this._logger.error('deployment failed: ' + error)

--- a/ingredient-template/src/plugin.ts
+++ b/ingredient-template/src/plugin.ts
@@ -2,7 +2,7 @@ import { BaseIngredient, IngredientManager } from "@azbake/core"
 
 export class MyCustomPlugin extends BaseIngredient {
 
-    public async Execute(): Promise<void> {
+    public async Execute(): Promise<any> {
         try {
             let util = IngredientManager.getIngredientFunction("coreutils", this._ctx)
             this._logger.log('Custom Plugin Logging: ' + this._ingredient.properties.source)

--- a/ingredient/ingredient-app-insights/src/plugin.ts
+++ b/ingredient/ingredient-app-insights/src/plugin.ts
@@ -3,16 +3,19 @@ import { ARMHelper } from "@azbake/arm-helper"
 import ARMTemplate from "./arm.json"
 
 export class AppInsightsPlugIn extends BaseIngredient {
-    public async Execute(): Promise<void> {
+    public async Execute(): Promise<any> {
         try {
             let util = IngredientManager.getIngredientFunction("coreutils", this._ctx)
+            let result: any[] = [];
+
             this._logger.log('Custom Plugin Logging: ' + this._ingredient.properties.source)
             
             const helper = new ARMHelper(this._ctx);
             
             let params = helper.BakeParamsToARMParams(this._name, this._ingredient.properties.parameters)
             
-            await helper.DeployTemplate(this._name, ARMTemplate, params, util.resource_group())
+            result.push( await helper.DeployTemplate(this._name, ARMTemplate, params, util.resource_group()) )
+            return result
             
         } catch(error){
             this._logger.error('deployment failed: ' + error)

--- a/ingredient/ingredient-arm/src/plugin.ts
+++ b/ingredient/ingredient-arm/src/plugin.ts
@@ -10,7 +10,7 @@ export class CustomArmIngredient extends BaseIngredient {
         super(name, ingredient, ctx)        
     }
 
-    public async Execute(): Promise<void> {
+    public async Execute(): Promise<any> {
 
         let source: string = this._ingredient.properties.source.value(this._ctx)
         let chk = fs.existsSync(source)
@@ -24,6 +24,7 @@ export class CustomArmIngredient extends BaseIngredient {
         try {
 
             this._logger.log('deployment for custom arm template: ' + source)
+            let result: any[] = [];
 
             const helper = new ARMHelper(this._ctx)
 
@@ -32,7 +33,8 @@ export class CustomArmIngredient extends BaseIngredient {
 
             let buffer = fs.readFileSync(source)
             let contents = buffer.toString()
-            await helper.DeployTemplate(this._name, JSON.parse(contents), props, util.resource_group());
+            result.push( await helper.DeployTemplate(this._name, JSON.parse(contents), props, util.resource_group()) );
+            return result
 
         } catch(error){
             this._logger.error('deployment failed: ' + error)

--- a/ingredient/ingredient-host-names/src/plugin.ts
+++ b/ingredient/ingredient-host-names/src/plugin.ts
@@ -9,12 +9,13 @@ export class HostNames extends BaseIngredient {
         super(name, ingredient, ctx);
     }
 
-    public async Execute(): Promise<void> {
+    public async Execute(): Promise<any> {
         
         let util = IngredientManager.getIngredientFunction("coreutils", this._ctx);
 
         try {
             const helper = new ARMHelper(this._ctx);
+            let result: any[] = [];
 
             //build the properties as a standard object.
             let props : any = {};
@@ -40,7 +41,8 @@ export class HostNames extends BaseIngredient {
             props["cert_name"] = { "value": util.create_resource_name("cert", null, true) };
             props["location"] = { "value": util.current_region().name };
 
-            await helper.DeployTemplate(this._name, hostarm, props, util.resource_group());
+            result.push( await helper.DeployTemplate(this._name, hostarm, props, util.resource_group()) );
+            return result
         }
         catch (error) {
             this._logger.error(`deployment failed: ${error}`);

--- a/ingredient/ingredient-webapp-container/src/plugin.ts
+++ b/ingredient/ingredient-webapp-container/src/plugin.ts
@@ -10,7 +10,7 @@ export class WebAppContainer extends BaseIngredient {
         super(name, ingredient, ctx);
     }
 
-    public async Execute(): Promise<void> {
+    public async Execute(): Promise<any> {
 
         let util = IngredientManager.getIngredientFunction("coreutils", this._ctx);
         let webapp = new WebAppUtils(this._ctx);
@@ -18,6 +18,7 @@ export class WebAppContainer extends BaseIngredient {
         try {
 
             var helper = new ARMHelper(this._ctx);
+            let result: any[] = [];
 
             //build the properties as a standard object.
             let props = helper.BakeParamsToARMParams(this._name, this._ingredient.properties.parameters);
@@ -39,7 +40,8 @@ export class WebAppContainer extends BaseIngredient {
             props["location"] = {"value": webAppRegion};
 
             
-            await helper.DeployTemplate(this._name, arm, props, util.resource_group());
+            result.push( await helper.DeployTemplate(this._name, arm, props, util.resource_group()) );
+            return result
 
         } catch(error){
             this._logger.error(`deployment failed: ${error}`);


### PR DESCRIPTION
In order to get the values back out of the deployment, that reflect any number of things that the template/ingredient designer may want to use in a downstream deployment, proper returns were added along with the proper references. The returns were specified as `array of any` because the deployment return has a possible value of `undefined` also, if there is multi region deployment such as in the traffic manager, an array may be needed. If it is a single element it will just be `return[0].properties`.