### PR TITLE
Feature/custom tags

### DIFF
--- a/arm-helper/src/arm-helper.ts
+++ b/arm-helper/src/arm-helper.ts
@@ -19,16 +19,8 @@ export class ARMHelper {
         const logger = new Logger(this._ctx.Logger.getPre().concat(deploymentName));
 
         try {
-
-            //set the baketags param (overwrite if it was already set)
-            params["baketags"] = {
-                "value": this.GenerateTags()
-            }
-
-            //now inject the param into the template as a param so it's linked.
-
-
-            //now iterate through all resources in the template and inject our tags.
+            //now iterate through all resources in the template and append our standard tags to any existing tags in the ARM template.
+            logger.log('appending standard tags');
             let resources: any[] = template.resources;
             resources.forEach( resource => {
                 let localTags = new Map<string,string>();

--- a/arm-helper/src/arm-helper.ts
+++ b/arm-helper/src/arm-helper.ts
@@ -26,14 +26,20 @@ export class ARMHelper {
             }
 
             //now inject the param into the template as a param so it's linked.
-            template.parameters.bakeTags = {
-                "type":"object"
-            }
+
 
             //now iterate through all resources in the template and inject our tags.
             let resources: any[] = template.resources;
             resources.forEach( resource => {
-                resource.tags = "[parameters('baketags')]"
+                let localTags = new Map<string,string>();
+                if (resource.tags)
+                {
+                    
+                    let map = Object.keys(resource.tags).forEach(k=>{
+                        localTags.set(k,resource.tags[k])
+                    })
+                }
+                resource.tags = this.GenerateTags(localTags)
             })
             template.resources = resources
 

--- a/ingredient/ingredient-app-insights/src/arm.json
+++ b/ingredient/ingredient-app-insights/src/arm.json
@@ -16,6 +16,9 @@
         "name": "[parameters('appInsightsName')]",
         "apiVersion": "2018-05-01-preview",
         "location": "[parameters('appInsightsLocation')]",
+        "tags": {
+          "Metrics": "requests/count"
+        },
         "properties": {
           "ApplicationId": "[parameters('appInsightsName')]",
           "Application_Type": "web",


### PR DESCRIPTION
Now retains custom tags within an ARM template when adding the standard tags.  Functionality needed for Azure Monitor Add-on for Splunk to allow exposed metrics to be defined in a Metrics tag.