### PR TITLE
Fix configuration by adding token section

### DIFF
--- a/Schema.md
+++ b/Schema.md
@@ -78,7 +78,8 @@ An ingredient block describes an instance of an ingredient to deploy. It has a l
 properties:
     type: string
     source: string
-    parameters {string: variable}
+    tokens: {string: variable}
+    parameters: {string: variable}
 dependsOn: [string]
 ```
 
@@ -86,6 +87,7 @@ dependsOn: [string]
 |----------|----------|------------|
 |type|yes|name of ingredient to deploy (check ingredient docs for name)|
 |source|depends on ingredient|source file/option for some ingredients|
+|tokens|depends on ingredient|Token values typically used to update configuration files when deployed.  Check ingredient docs for token options|
 |parameters|depends on ingredient|check ingredient docs for parameter options|
 |dependsOn|no|list of ingredient blocks that must be deployed before this block|
 

--- a/core/src/bake-interfaces.ts
+++ b/core/src/bake-interfaces.ts
@@ -24,7 +24,8 @@ export interface IBakeEnvironment {
 export interface IIngredientProperties {
     type: string,
     source: BakeVariable,
-    parameters: Map<string,BakeVariable>
+    parameters: Map<string,BakeVariable>,
+    tokens: Map<string,BakeVariable>
 }
 
 export interface IIngredientType {

--- a/ingredient/ingredient-webapp-container/README.md
+++ b/ingredient/ingredient-webapp-container/README.md
@@ -22,6 +22,9 @@ recipe:
     properties:
       type: "@azbake/ingredient-webapp-container"
       source: "[coreutils.get_app_svc_name('ngapp')]"
+      tokens:
+        BASE_URL: "[coreutils.variable('svc_base_url')]"
+        PROPERTY: "some value"
       parameters:
         container_image_name: "myregistry.azurecr.io/mypkg:latest"
         container_registry_url: "[coreutils.variable('container_registry_url')]"
@@ -41,6 +44,9 @@ recipe:
 ***  Please note that you can supply just the name of the azure resource for the source if the resource exists within the same resource group that is currently being deployed for traffic manager.
 
 *** Please note that all values should be in the parameters section of the recipe except for source
+
+### Tokens
+The token section of the ingredient can be used to specify any values you wished to be pushed into the environment variables of the container running your web application.  Very useful for updating configuration files.  Tokens are optional and can be omitted if not needed.
 
 ### Best Practices
 Since there is some secure information required to deploy your web site in a container, it si recommended that this information should be stored inside of the environment and referenced through ``coreutils.variable()``.  Do not set these values in the recipe itself as it could risk exposing this information publicly. Sample above uses this method to keep secure user credentials and password for the container registry.

--- a/system/src/bake-loader.ts
+++ b/system/src/bake-loader.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs'
 import {BakeVariable, IBakeEnvironment, IBakeConfig, IBakeAuthentication,
     IIngredientProperties, IIngredient, Logger, IngredientManager} from '@azbake/core'
 import { ShellRunner } from 'azcli-npm';
+import { stringify } from 'querystring';
 
 export class BakePackage {
     constructor(source: string) {
@@ -158,6 +159,7 @@ export class BakePackage {
             ingredient.dependsOn = ingredient.dependsOn || []
             ingredient.properties = ingredient.properties || <IIngredientProperties>{}
             ingredient.properties.parameters = this.objToVariableMap(ingredient.properties.parameters || {})
+            ingredient.properties.tokens = this.objToVariableMap(ingredient.properties.tokens || new Map<string, BakeVariable>())
         })
 
         this._validatePackage(config)


### PR DESCRIPTION
Adds token section to the ingredient to allow ingredients to use these as configuration tokens during deployment.  Ingredient-webapp-container uses this to dynamically update appsettings on the arm template to push the token values into the container as environment variables at runtime.