### PR TITLE
Fixed npm authenticate

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,8 +53,9 @@ steps:
 
 - task: npmAuthenticate@0
   inputs:
+    workingFile: '$(System.DefaultWorkingDirectory)/.npmrc'
     customEndpoint: 'hchb-npm-public-registry'
-    
+
 - task: Npm@1
   inputs:
     command: 'install'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,6 +51,10 @@ steps:
     command: Login
     containerRegistry: HCHBDockerHub
 
+- task: npmAuthenticate@0
+  inputs:
+    customEndpoint: 'hchb-npm-public-registry'
+    
 - task: Npm@1
   inputs:
     command: 'install'
@@ -66,10 +70,6 @@ steps:
     gulpFile: 'gulpfile.js' 
     targets: 'listenvironment'    
     workingDirectory: '$(System.DefaultWorkingDirectory)'        
-
-- task: npmAuthenticate@0
-  inputs:
-    customEndpoint: 'hchb-npm-public-registry'
 
 - task: gulp@1
   displayName: GULP Build and Release


### PR DESCRIPTION
Perused the NPM AzureDevops [tasks on GitHub](https://github.com/microsoft/azure-pipelines-tasks.git) and found that a field was left out of the build. I set the `.npmrc` path field as well as creating an actual `.npmrc` with the default of `registry=https://registry.npmjs.org`. Proof of concept is [here](https://hchb.visualstudio.com/HCHB/_build/results?buildId=75363)