### PR TITLE
CI Trigger Fix

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,7 +63,7 @@ steps:
   displayName: GULP List Environment
   inputs:
     gulpFile: 'gulpfile.js' 
-    targets: 'listenvironment'    
+    targets: 'listenvironment'
     workingDirectory: '$(System.DefaultWorkingDirectory)'        
 
 - task: gulp@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,6 +73,7 @@ steps:
     targets: 'build'    
     workingDirectory: '$(System.DefaultWorkingDirectory)'    
     arguments: --sonarToken '$(SonarQubeToken)'
+  condition: not(contains(variables['Build.SourceVersionMessage'], '[skip ci]'))
 
 - task: Docker@2
   displayName: Logout from DockerHub


### PR DESCRIPTION
Added build condition to exclude commits with `[skip ci]` in the Title. This is supposed to be a core functionality for Azure DevOps CI/CD, but it is apparently broken for the GitHub integration.

Continue Test: https://hchb.visualstudio.com/HCHB/_build/results?buildId=76284
Skip Test: https://hchb.visualstudio.com/HCHB/_build/results?buildId=76277