### PR TITLE
Reset the NPM Key before build commits it

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-//registry.npmjs.org/:_authToken=ed59a8e5-6eff-41e0-88f7-84bd8dac4af2
+//registry.npmjs.org/:_authToken=$(Npm_Auth_Token)

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,17 @@
 {
     "workbench.colorCustomizations": {
-        "activityBar.background": "#1E3305",
-        "titleBar.activeBackground": "#2A4807",
-        "titleBar.activeForeground": "#F3FDE8"
-    }
+        "activityBar.background": "#223800",
+        "activityBar.foreground": "#e7e7e7",
+        "activityBar.inactiveForeground": "#e7e7e799",
+        "activityBarBadge.background": "#0074bf",
+        "activityBarBadge.foreground": "#e7e7e7",
+        "titleBar.activeBackground": "#030500",
+        "titleBar.inactiveBackground": "#03050099",
+        "titleBar.activeForeground": "#e7e7e7",
+        "titleBar.inactiveForeground": "#e7e7e799",
+        "statusBar.background": "#030500",
+        "statusBarItem.hoverBackground": "#223800",
+        "statusBar.foreground": "#e7e7e7"
+    },
+    "peacock.color": "#030500"
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -32,7 +32,7 @@ function build(done) {
         if ((!!params.build.buildReason.match(/IndividualCI/ig) || !!params.build.buildReason.match(/BatchedCI/ig)) &&
             !!params.build.buildSourceBranch.replace(/refs\/heads\/(feature\/)?/i, '').match(/master/ig)) {
             console.log('Running Azure DevOps Release Build');
-            gulp.series(printVersion, adoPrep, toolInstall, lernaBuild, gitCommit, lernaPublish, systemPublish, resetNpmAuth, tagAndPush)(done);
+            gulp.series(printVersion, adoPrep, toolInstall, lernaBuild, gitCommit, lernaPublish, resetNpmAuth, systemPublish, tagAndPush)(done);
         }
 
         else if (!!params.build.buildReason.match(/PullRequest/ig)) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -32,7 +32,7 @@ function build(done) {
         if ((!!params.build.buildReason.match(/IndividualCI/ig) || !!params.build.buildReason.match(/BatchedCI/ig)) &&
             !!params.build.buildSourceBranch.replace(/refs\/heads\/(feature\/)?/i, '').match(/master/ig)) {
             console.log('Running Azure DevOps Release Build');
-            gulp.series(printVersion, adoPrep, toolInstall, lernaBuild, gitCommit, lernaPublish, systemPublish, tagAndPush)(done);
+            gulp.series(printVersion, adoPrep, toolInstall, lernaBuild, gitCommit, lernaPublish, systemPublish, resetNpmAuth, tagAndPush)(done);
         }
 
         else if (!!params.build.buildReason.match(/PullRequest/ig)) {
@@ -258,6 +258,21 @@ function writeFilenameToFile() {
         //Callback signals the operation is done and returns the object to the pipeline
         cb(null, file);
     });
+}
+
+function resetNpmAuth() {
+    let filename = './.npmrc'
+    let npmString = '//registry.npmjs.org/:_authToken=$(Npm_Auth_Token)'
+    src._read = function () {
+        this.push(new gutil.File({
+          cwd: "",
+          base: "",
+          path: filename,
+          contents: new Buffer(npmString)
+        }))
+        this.push(null)
+      }
+      return src
 }
 
 //Tasks


### PR DESCRIPTION
Currently, the NPM key is set and is committed to the repository incidentally by a build process that automatically generates a GitHub release. This key needs to be cleared to prevent it being committed to the public repository.