### PR TITLE
Added shortname to create resource name functions

### DIFF
--- a/ingredient/ingredient-availability-set/src/functions.ts
+++ b/ingredient/ingredient-availability-set/src/functions.ts
@@ -3,10 +3,10 @@ import { ResourceManagementClient } from '@azure/arm-resources';
 
 export class AvailabilitySetUtils extends BaseUtility {
 
-    public create_resource_name(): string {
+    public create_resource_name(shortName: string): string {
         let util = IngredientManager.getIngredientFunction("coreutils", this.context);
 
-        const name = util.create_resource_name("avail", null, true);
+        const name = util.create_resource_name("avail", shortName, true);
         return name;
     }
 

--- a/ingredient/ingredient-availability-set/src/functions.ts
+++ b/ingredient/ingredient-availability-set/src/functions.ts
@@ -3,10 +3,10 @@ import { ResourceManagementClient } from '@azure/arm-resources';
 
 export class AvailabilitySetUtils extends BaseUtility {
 
-    public create_resource_name(shortName: string): string {
+    public create_resource_name(shortName?: string): string {
         let util = IngredientManager.getIngredientFunction("coreutils", this.context);
 
-        const name = util.create_resource_name("avail", shortName, true);
+        const name = util.create_resource_name("avail", (shortName != undefined) ? shortName : null, true);
         return name;
     }
 

--- a/ingredient/ingredient-azure-vm/src/functions.ts
+++ b/ingredient/ingredient-azure-vm/src/functions.ts
@@ -2,9 +2,10 @@ import {BaseUtility, IngredientManager} from '@azbake/core'
 
 export class AzureVmUtils extends BaseUtility {
 
-    public create_resource_name(shortName: string): string {
+    public create_resource_name(shortName?: string): string {
         let util = IngredientManager.getIngredientFunction("coreutils", this.context);
-        const name = util.create_resource_name("vm", shortName, false);
+        const name = util.create_resource_name("vm", (shortName != undefined) ? shortName : null, false);
         return name;
     }
+   
 }

--- a/ingredient/ingredient-azure-vm/src/functions.ts
+++ b/ingredient/ingredient-azure-vm/src/functions.ts
@@ -2,9 +2,9 @@ import {BaseUtility, IngredientManager} from '@azbake/core'
 
 export class AzureVmUtils extends BaseUtility {
 
-    public create_resource_name(): string {
+    public create_resource_name(shortName: string): string {
         let util = IngredientManager.getIngredientFunction("coreutils", this.context);
-        const name = util.create_resource_name("vm", null, false);
+        const name = util.create_resource_name("vm", shortName, false);
         return name;
     }
 }

--- a/ingredient/ingredient-network-interface/src/functions.ts
+++ b/ingredient/ingredient-network-interface/src/functions.ts
@@ -2,10 +2,11 @@ import {BaseUtility, IngredientManager} from '@azbake/core'
 import { NetworkManagementClient } from "@azure/arm-network";
 export class NetworkInterfaceUtils extends BaseUtility {
 
-    public create_resource_name(shortName: string): string {
+    public create_resource_name(shortName?: string): string {
 
         let util = IngredientManager.getIngredientFunction("coreutils", this.context)
-        const name = util.create_resource_name("ni", shortName, false);
+      
+        const name = util.create_resource_name("ni", (shortName != undefined) ? shortName : null, false);
         return name;
     }   
 

--- a/ingredient/ingredient-network-interface/src/functions.ts
+++ b/ingredient/ingredient-network-interface/src/functions.ts
@@ -2,10 +2,10 @@ import {BaseUtility, IngredientManager} from '@azbake/core'
 import { NetworkManagementClient } from "@azure/arm-network";
 export class NetworkInterfaceUtils extends BaseUtility {
 
-    public create_resource_name() {
+    public create_resource_name(shortName: string): string {
 
         let util = IngredientManager.getIngredientFunction("coreutils", this.context)
-        const name = util.create_resource_name("ni", null, false);
+        const name = util.create_resource_name("ni", shortName, false);
         return name;
     }   
 


### PR DESCRIPTION
Updated create_resource_name functions to include  shortname parameter. We need ability to create multiple availability sets, network interfaces, VMs in each environment, so using the shortname added to name helps to create unique names.