### PR TITLE
add stock diagnostics for all API deployed to APIM

### DIFF
--- a/ingredient/ingredient-apim-api/README.md
+++ b/ingredient/ingredient-apim-api/README.md
@@ -67,6 +67,7 @@ apis: #follows this azure spec for *ApiVersionSetContract* : https://github.com/
 versions: #follows this azure spec for *ApiCreateOrUpdateParameter* : https://github.com/Azure/azure-sdk-for-js/blob/20fe312b1122b21811f9364e3d95fe77202e6466/sdk/apimanagement/arm-apimanagement/src/models/index.ts#L1310
   - name: <api-name> #typically you want set the id to <api-version-id>-<version> to keep the id consistant for the version set it belongs to - required
     version: <string> #version string that will be used as part of the above ApiVersionSetContract.versioningSchema      
+    stockDiagnosticSamplingRate: <number> #option value for the sampling rate of the stock app insights diagnostics.
     products: #optional list of product names to assign API to
     policies: #see next section for policy schema
     diagnostics: #see next section for diagnostic schema

--- a/ingredient/ingredient-apim-api/README.md
+++ b/ingredient/ingredient-apim-api/README.md
@@ -66,8 +66,7 @@ apis: #follows this azure spec for *ApiVersionSetContract* : https://github.com/
 ```yaml
 versions: #follows this azure spec for *ApiCreateOrUpdateParameter* : https://github.com/Azure/azure-sdk-for-js/blob/20fe312b1122b21811f9364e3d95fe77202e6466/sdk/apimanagement/arm-apimanagement/src/models/index.ts#L1310
   - name: <api-name> #typically you want set the id to <api-version-id>-<version> to keep the id consistant for the version set it belongs to - required
-    version: <string> #version string that will be used as part of the above ApiVersionSetContract.versioningSchema      
-    stockDiagnosticSamplingRate: <number> #option value for the sampling rate of the stock app insights diagnostics.
+    version: <string> #version string that will be used as part of the above ApiVersionSetContract.versioningSchema
     products: #optional list of product names to assign API to
     policies: #see next section for policy schema
     diagnostics: #see next section for diagnostic schema

--- a/ingredient/ingredient-apim-api/src/plugin.ts
+++ b/ingredient/ingredient-apim-api/src/plugin.ts
@@ -24,7 +24,6 @@ interface IApimApiVersion extends ApiVersionSetContract{
 interface IApimApi extends ApiCreateOrUpdateParameter{
     name : string
     version: string
-    stockDiagnosticSamplingRate?: number,
     policies?: Array<IApimPolicy>
     products?: Array<string>
     diagnostics?: Array<IApimApiDiagnostics>
@@ -167,10 +166,6 @@ export class ApimApiPlugin extends BaseIngredient {
         if (api.value) {
             api.value = (await (new BakeVariable(api.value)).valueAsync(this._ctx))
         }
-
-        if (api.stockDiagnosticSamplingRate) {
-            api.stockDiagnosticSamplingRate = parseInt((await (new BakeVariable(api.stockDiagnosticSamplingRate.toString())).valueAsync(this._ctx)))
-        }
         
         let apimOptions = (this.apim_options || <IApimOptions>{});
 
@@ -237,8 +232,8 @@ export class ApimApiPlugin extends BaseIngredient {
 
             if (aiDiag && aiDiag.sampling) {
 
-                if(api.stockDiagnosticSamplingRate) {
-                    aiDiag.sampling.percentage = api.stockDiagnosticSamplingRate;
+                if (this._ctx.Environment.environmentCode == stockDiagnostics.appInsights.prodOverrides.envCode) {
+                    aiDiag.sampling.percentage = stockDiagnostics.appInsights.prodOverrides.sampling.percentage;
                 }
                     
                 await this.ApplyApiDiagnostics(aiDiag, api.name)

--- a/ingredient/ingredient-apim-api/src/stockDiagnostics.json
+++ b/ingredient/ingredient-apim-api/src/stockDiagnostics.json
@@ -1,0 +1,11 @@
+{
+  "appInsights": {
+    "name": "applicationinsights",
+    "loggerId": "[(await apim.get_logger(await apim.get_resource_group(), await apim.get_resource_name(), await appinsights.get_resource_name('apimhchbapi'))).id]",
+    "alwaysLog": "allErrors",
+    "sampling": {
+      "samplingType": "fixed",
+      "percentage": 100
+    }
+  }
+}

--- a/ingredient/ingredient-apim-api/src/stockDiagnostics.json
+++ b/ingredient/ingredient-apim-api/src/stockDiagnostics.json
@@ -6,6 +6,12 @@
     "sampling": {
       "samplingType": "fixed",
       "percentage": 100
+    },
+    "prodOverrides": {
+      "envCode": "PRD",
+      "sampling": {
+        "percentage": 10
+      }
     }
   }
 }


### PR DESCRIPTION
Need ability to apply stock app insights diagnostics to all API by default so developers do not need to worry about setting them up in their API recipe. 