### PR TITLE
Disable app insights smart detection notifications, fix action groups

### DIFF
--- a/ingredient/ingredient-app-insights/src/arm.json
+++ b/ingredient/ingredient-app-insights/src/arm.json
@@ -35,7 +35,7 @@
             ],
             "properties": {
               "name": "slowpageloadtime",
-              "sendEmailsToSubscriptionOwners": true,
+              "sendEmailsToSubscriptionOwners": false,
               "customEmails": [],
               "enabled": true
             }
@@ -50,7 +50,7 @@
             ],
             "properties": {
               "name": "slowserverresponsetime",
-              "sendEmailsToSubscriptionOwners": true,
+              "sendEmailsToSubscriptionOwners": false,
               "customEmails": [],
               "enabled": true
             }
@@ -65,7 +65,7 @@
             ],
             "properties": {
               "name": "longdependencyduration",
-              "sendEmailsToSubscriptionOwners": true,
+              "sendEmailsToSubscriptionOwners": false,
               "customEmails": [],
               "enabled": true
             }
@@ -80,7 +80,7 @@
             ],
             "properties": {
               "name": "degradationinserverresponsetime",
-              "sendEmailsToSubscriptionOwners": true,
+              "sendEmailsToSubscriptionOwners": false,
               "customEmails": [],
               "enabled": true
             }
@@ -95,7 +95,7 @@
             ],
             "properties": {
               "name": "degradationindependencyduration",
-              "sendEmailsToSubscriptionOwners": true,
+              "sendEmailsToSubscriptionOwners": false,
               "customEmails": [],
               "enabled": true
             }
@@ -110,7 +110,7 @@
             ],
             "properties": {
               "name": "extension_traceseveritydetector",
-              "sendEmailsToSubscriptionOwners": true,
+              "sendEmailsToSubscriptionOwners": false,
               "customEmails": [],
               "enabled": true
             }
@@ -125,7 +125,7 @@
             ],
             "properties": {
               "name": "extension_exceptionchangeextension",
-              "sendEmailsToSubscriptionOwners": true,
+              "sendEmailsToSubscriptionOwners": false,
               "customEmails": [],
               "enabled": true
             }
@@ -140,7 +140,7 @@
             ],
             "properties": {
               "name": "extension_memoryleakextension",
-              "sendEmailsToSubscriptionOwners": true,
+              "sendEmailsToSubscriptionOwners": false,
               "customEmails": [],
               "enabled": true
             }
@@ -155,7 +155,7 @@
             ],
             "properties": {
               "name": "extension_securityextensionspackage",
-              "sendEmailsToSubscriptionOwners": true,
+              "sendEmailsToSubscriptionOwners": false,
               "customEmails": [],
               "enabled": true
             }
@@ -170,7 +170,7 @@
             ],
             "properties": {
               "name": "extension_billingdatavolumedailyspikeextension",
-              "sendEmailsToSubscriptionOwners": true,
+              "sendEmailsToSubscriptionOwners": false,
               "customEmails": [],
               "enabled": true
             }

--- a/ingredient/ingredient-app-insights/src/stockAlerts.json
+++ b/ingredient/ingredient-app-insights/src/stockAlerts.json
@@ -17,6 +17,6 @@
                 "minFailingPeriodsToAlert": "6"
             }
         },
-        "actionGroups": [{"actionGroupShortName": "opsgenie"}]        
+        "actionGroups": [{"actionGroupShortName": "opsgenieAppAlert"}]        
     }    
 }

--- a/ingredient/ingredient-event-hub-namespace/src/stockAlerts.json
+++ b/ingredient/ingredient-event-hub-namespace/src/stockAlerts.json
@@ -68,6 +68,6 @@
         "evaluationFrequency": "PT15M",
         "alertType": "Static",
         "threshold": "4500",
-        "actionGroups": [{"actionGroupShortName": "opsgenie"}]        
+        "actionGroups": [{"actionGroupShortName": "opsgenieInfraAlert"}]        
     }
 }

--- a/ingredient/ingredient-service-bus-namespace/src/stockAlerts.json
+++ b/ingredient/ingredient-service-bus-namespace/src/stockAlerts.json
@@ -68,7 +68,7 @@
         "evaluationFrequency": "PT15M",
         "alertType": "Static",
         "threshold": "4500",
-        "actionGroups": [{"actionGroupShortName": "opsgenie"}]        
+        "actionGroups": [{"actionGroupShortName": "opsgenieInfraAlert"}]        
     },
     "DeadletteredMessages": {
         "alertDescription": "static count of dead-lettered messages in a Queue/Topic. ",
@@ -95,7 +95,7 @@
         "evaluationFrequency": "PT15M",
         "alertType": "Static",
         "threshold": "77309411328",
-        "actionGroups": [{"actionGroupShortName": "opsgenie"}]        
+        "actionGroups": [{"actionGroupShortName": "opsgenieInfraAlert"}]        
     },
     "CPUXNS": {
         "alertDescription": "The CPU metric's average value has exceeded 95% for longer than the duration allowed.",

--- a/ingredient/ingredient-storage/src/stockAlerts.json
+++ b/ingredient/ingredient-storage/src/stockAlerts.json
@@ -55,6 +55,6 @@
         "evaluationFrequency": "PT15M",
         "alertType": "Static",
         "threshold": "16200000",
-        "actionGroups": [{"actionGroupShortName": "opsgenie"}]        
+        "actionGroups": [{"actionGroupShortName": "opsgenieInfraAlert"}]        
     }
 }

--- a/ingredient/ingredient-traffic-manager/src/stockAlerts.json
+++ b/ingredient/ingredient-traffic-manager/src/stockAlerts.json
@@ -11,6 +11,6 @@
         "evaluationFrequency": "PT5M",
         "alertType": "Static",
         "threshold": "1",
-        "actionGroups": [{"actionGroupShortName": "opsgenie"}]
+        "actionGroups": [{"actionGroupShortName": "opsgenieInfraAlert"}]
     }
 }


### PR DESCRIPTION
Disable notifications for app insights smart detection feature.  The notifications it's sending is just noise.

Also split action groups to match what's deployed to Azure (previously missed for some reason).
