### PR TITLE
Allow API's to move products and fix AppInsights Logger Key cleanup

### DIFF
--- a/ingredient/ingredient-apim-api/src/plugin.ts
+++ b/ingredient/ingredient-apim-api/src/plugin.ts
@@ -369,6 +369,20 @@ export class ApimApiPlugin extends BaseIngredient {
 
         if (this.apim_client == undefined) return
 
+        //Clean existing products if different than the one you are assigning to
+        var existingProducts = await this.apim_client.apiProduct.listByApis(this.resource_group, this.resource_name, apiId);
+
+        for (let i = 0; i < existingProducts.length; i++) {
+            let oldProductId = existingProducts[i].name || ""
+
+            if(oldProductId != productId)
+            {
+                await this.apim_client.productApi.deleteMethod(this.resource_group, this.resource_name, oldProductId, apiId)
+                .then((result) => { this._logger.log('APIM API Plugin: Deleting API: ' + apiId + " from product " + oldProductId)})
+                .catch((failure) => {this._logger.error("APIM API Plugin: Could not delete API " + apiId + "from product " + oldProductId) })
+            }
+        }
+        
         this._logger.log('APIM API Plugin: Assigning APIs: ' + apiId + " to product " + productId)
 
         let apiResponse = await this.apim_client.productApi.createOrUpdate(this.resource_group, this.resource_name, productId, apiId)

--- a/ingredient/ingredient-apim/src/plugin.ts
+++ b/ingredient/ingredient-apim/src/plugin.ts
@@ -580,7 +580,7 @@ export class ApimPlugin extends BaseIngredient {
                 for (let i = 0; i < result.length; i++) {
                     let id = result[i].name || ""
                     let displayName = result[i].displayName || ""
-                    if (displayName != currentLoggerCreds && displayName.match(/Logger.Credentials-.*/) && result[i].value == aiKey) {
+                    if (displayName != currentLoggerCreds && displayName.match(/Logger.Credentials-.*/) && result[i].secret) {
                         await this.apim_client.namedValue.getEntityTag(this.resource_group, this.resource_name, id).then((result) => { propEtag = result.eTag })
                         await this.apim_client.namedValue.deleteMethod(this.resource_group, this.resource_name, id, propEtag)
                             .then((result) => {


### PR DESCRIPTION
- At some point AppInsights Logger Key named values became secrets which broke the cleanup. The value is no longer returned so just checking on the name regex and whether the named value is a secret in order to clean them up.
- Since API's can only be attached to one product, I made an enhancement that allows moving an API to a different product simply by changing the product it's assigned to in the bake recipe. The ingredient will now delete the old registration if different than the new one.