### PR TITLE
Add kubectlFlags Parameter to Kubernetes Ingredient

### DIFF
--- a/ingredient/ingredient-kubernetes/README.md
+++ b/ingredient/ingredient-kubernetes/README.md
@@ -40,6 +40,7 @@ recipe:
         kubeconfig : ["coreutils.variable('b64KubeConfigContent')"]
         testDeployment: true #set this to true and after the source has been applied, it will get deleted (good for deployment testing)
         deleteDeployment: false # not required, and if set to true it will execute a kubectl delete instead of a kubectl apply on the subdir (ignoring anything not found)
+        kubectlFlags: "--server-side --force-conflicts" # optionally specify additional flags for kubectl command
 ~~~
 # Limitations
 * Token replacement will not happen against URLs specified as the `source` of the ingredient.

--- a/ingredient/ingredient-kubernetes/src/plugin.ts
+++ b/ingredient/ingredient-kubernetes/src/plugin.ts
@@ -33,6 +33,7 @@ export class KubernetesPlugin extends BaseIngredient {
 
             let testDeployment = this._ingredient.properties.parameters.get("testDeployment");
             let deleteDeployment = this._ingredient.properties.parameters.get("deleteDeployment");
+            let kubectlFlags = this._ingredient.properties.parameters.get("kubectlFlags");
             let kubeConfigParam = await this.getKubeConfigParameter(kubeconfigFilename);
 
             await this.replaceTokens(k8sYamlPath);
@@ -41,9 +42,11 @@ export class KubernetesPlugin extends BaseIngredient {
 
             try {
 
-                let execString = `kubectl apply ${kubeConfigParam} -f ${k8sYamlPath}`;
+                let flags = kubectlFlags ? await kubectlFlags.valueAsync(this._ctx) : "";
+
+                let execString = `kubectl apply ${kubeConfigParam} -f ${k8sYamlPath} ${flags}`;
                 if (deleteDeployment && await deleteDeployment.valueAsync(this._ctx)){
-                    execString = `kubectl delete ${kubeConfigParam} -f ${k8sYamlPath} --ignore-not-found=true`;
+                    execString = `kubectl delete ${kubeConfigParam} -f ${k8sYamlPath} --ignore-not-found=true ${flags}`;
                 }
 
                 const stdout = execSync(execString);


### PR DESCRIPTION
Add `kubectlFlags` parameter to the Kubernetes ingredient to allow specifying additional flags for the `kubectl` command.