### PR TITLE
get more specific details from ARM RestError

### DIFF
--- a/arm-helper/src/arm-helper.ts
+++ b/arm-helper/src/arm-helper.ts
@@ -4,6 +4,7 @@ import { Deployment, DeploymentProperties } from '@azure/arm-resources/esm/model
 import { stringify } from 'querystring';
 import { AnyCnameRecord } from 'dns';
 import alertTemplate from "./alert.json"
+import { RestError } from '@azure/ms-rest-js';
 
 export class ARMHelper {
 
@@ -81,7 +82,8 @@ export class ARMHelper {
             logger.log('deployment finished...');
 
         } catch(error) {
-            logger.error('deployment failed: ' + error);
+            if (error instanceof RestError) error = JSON.stringify(error.body.error.details); // [string]error misses Azure deployment failure messages. 
+            logger.error('deployment failed: ' + error); 
             throw error;
         }
     }


### PR DESCRIPTION
Some details of ARM deployment errors are lost when logging simply the caught `[string[error`. Getting the `.body.error.details` from `error` gives the user more information.

I admit this isn't the most elegant way to handle this; formatted JSON in the log is a bit messy. I'm open to improvements from reviewers more js-fluent than I.