### PR TITLE
Fix: parameter value was incorrectly named

### DIFF
--- a/ingredient/ingredient-postgresql/src/plugin.ts
+++ b/ingredient/ingredient-postgresql/src/plugin.ts
@@ -25,7 +25,7 @@ export class PostgreSQLDB extends BaseIngredient {
         let params: any;
         try {
             params = await this._helper.BakeParamsToARMParamsAsync(this._name, this._ingredient.properties.parameters)
-            this._access = params.access._value.toLowerCase();
+            this._access = params.access.value.toLowerCase();
             if (this._access == "public") {
                 this._armTemplate = PublicAccessARMTemplate
             } else if (this._access == "private") {


### PR DESCRIPTION
This was tested and worked with the underscore, I'm sure of it. Now, though, that's not how the property is named. There should be no underscore. I am unsure how this worked at the time of the last PR.