### PR TITLE
fix: Postgresql depends on newer typescript

### DIFF
--- a/ingredient/ingredient-postgresql/package.json
+++ b/ingredient/ingredient-postgresql/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azbake/ingredient-postgresql",
   "description": "Ingredient for deploying an instance of PostgreSQL.",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "main": "dist/index.js",
   "typings": "src/index.ts",
   "author": "HCHB",
@@ -32,7 +32,8 @@
     "@azbake/arm-helper": "^0.1.109",
     "@azure/arm-network": "^26.0.0",
     "@azure/arm-privatedns": "^3.0.0",
-    "@azure/identity": "^2.0.4"
+    "@azure/identity": "^2.0.4",
+    "typescript": "^4.6.0"
   },
   "publishConfig": {
     "access": "public",

--- a/ingredient/ingredient-postgresql/src/plugin.ts
+++ b/ingredient/ingredient-postgresql/src/plugin.ts
@@ -13,7 +13,6 @@ export class PostgreSQLDB extends BaseIngredient {
         super(name, ingredient, ctx);
         this._helper = new ARMHelper(this._ctx);
         this._functions = new PostgreSQLDBUtils(this._ctx);
-
     }
 
     _helper: ARMHelper;
@@ -61,7 +60,6 @@ export class PostgreSQLDB extends BaseIngredient {
 
         try {
             const util = IngredientManager.getIngredientFunction("coreutils", this._ctx);
-            this._logger.log('PostgreSQL Plugin Logging: ' + this._ingredient.properties.parameters)
             await this._helper.DeployTemplate(this._name, this._armTemplate, params, await util.resource_group())
         } catch(error){
             this._logger.error('Deployment failed: ' + error)


### PR DESCRIPTION
Some Azure SDK dependencies depend on newer typescript. I cleaned up a nonsense logger line while we're at it.