### PR TITLE
fix deployment name param access

### DIFF
--- a/ingredient/ingredient-postgresql/src/plugin.ts
+++ b/ingredient/ingredient-postgresql/src/plugin.ts
@@ -44,9 +44,9 @@ export class PostgreSQLDB extends BaseIngredient {
             params.vnetData = await this.getVnetData(params);
 
             // Microsoft.Resources/deployments reuse deployment names because they aren't cleaned up.
-            params.virtualNetworkDeploymentName = {value: `virtualNetwork_${params.serverName}`};
-            params.virtualNetworkLinkDeploymentName = {value: `virtualNetworkLink_${params.serverName}`};
-            params.privateDnsZoneDeploymentName = {value: `privateDnsZone_${params.serverName}`};
+            params.virtualNetworkDeploymentName = {value: `virtualNetwork_${params.serverName.value}`};
+            params.virtualNetworkLinkDeploymentName = {value: `virtualNetworkLink_${params.serverName.value}`};
+            params.privateDnsZoneDeploymentName = {value: `privateDnsZone_${params.serverName.value}`};
             
             // Hard coding this for security
             params.publicNetworkAccess = {value: 'Disabled'};


### PR DESCRIPTION
I introduced this bug a month ago during linting, which I apparently didn't test.

I ran this locally on a fresh environment and it succeeded, so I am hopeful that this is the last PR for postgresql for a while.