### PR TITLE
Update kubectl to 1.19.16

### DIFF
--- a/system/Dockerfile
+++ b/system/Dockerfile
@@ -5,7 +5,7 @@ ENV NODE_ENV production
 # Install kubectl
 # Note: Latest version may be found on:
 # https://aur.archlinux.org/packages/kubectl-bin/
-ADD https://storage.googleapis.com/kubernetes-release/release/v1.17.17/bin/linux/amd64/kubectl /usr/local/bin/kubectl
+ADD https://storage.googleapis.com/kubernetes-release/release/v1.19.16/bin/linux/amd64/kubectl /usr/local/bin/kubectl
 
 RUN set -x \
     && apk add --no-cache bash \


### PR DESCRIPTION
Updated kubectl 1.19.16 to maintain compatibility with RKE (on-prem)