### PR TITLE
fix: apim diagnostics error fix

### DIFF
--- a/ingredient/ingredient-apim-api/src/plugin.ts
+++ b/ingredient/ingredient-apim-api/src/plugin.ts
@@ -329,16 +329,31 @@ export class ApimApiPlugin extends BaseIngredient {
 
         this._logger.log('APIM API Plugin: Applying diagnostics ' + diagnostics.name + " to API " + apiId)
 
-        let apiResponse = await this.apim_client.apiDiagnostic.createOrUpdate(
-            this.resource_group,
-            this.resource_name,
-            apiId,
-            diagnostics.name,
-            diagnostics,
-            <DiagnosticCreateOrUpdateOptionalParams>{ifMatch:'*'})
+        for(let i=0; i <= 3; ++i) {
+            let logErrMessage = "APIM API Plugin: Could not apply diagnostics " + diagnostics.name + " to API " + apiId;
+            try {
+                let apiResponse = await this.apim_client.apiDiagnostic.createOrUpdate(
+                    this.resource_group,
+                    this.resource_name,
+                    apiId,
+                    diagnostics.name,
+                    diagnostics,
+                    <DiagnosticCreateOrUpdateOptionalParams>{ifMatch:'*'})
         
-        if (apiResponse._response.status != 200 && apiResponse._response.status != 201){
-            this._logger.error("APIM API Plugin: Could not apply diagnostics " + diagnostics.name + "to API " + apiId)
+                if (apiResponse._response.status != 200 && apiResponse._response.status != 201){
+                    this._logger.error(logErrMessage)
+                }
+
+                break; 
+            } catch (error) {
+                if (i == 3) {
+                    this._logger.error(logErrMessage + " due to error '" + error + "'")
+                }
+                else {
+                    this._logger.error(logErrMessage + " - retrying")
+                    await this.Sleep(1000);
+                }
+            }
         }
     }
 

--- a/ingredient/ingredient-apim-api/src/plugin.ts
+++ b/ingredient/ingredient-apim-api/src/plugin.ts
@@ -326,6 +326,7 @@ export class ApimApiPlugin extends BaseIngredient {
                 diagnostics.loggerId = logger.id   
             }
         }
+        
         this._logger.log('APIM API Plugin: Applying diagnostics ' + diagnostics.name + " to API " + apiId)
 
         let applyDiagnostic = true;

--- a/ingredient/ingredient-apim/src/plugin.ts
+++ b/ingredient/ingredient-apim/src/plugin.ts
@@ -822,8 +822,18 @@ export class ApimPlugin extends BaseIngredient {
                 let hostnameConfiguration = apim.hostnameConfigurations[i];
 
                 hostnameConfiguration.hostName = (await (new BakeVariable(hostnameConfiguration.hostName)).valueAsync(this._ctx));
-                hostnameConfiguration.encodedCertificate = (await (new BakeVariable(hostnameConfiguration.encodedCertificate)).valueAsync(this._ctx));
-                hostnameConfiguration.certificatePassword = (await (new BakeVariable(hostnameConfiguration.certificatePassword)).valueAsync(this._ctx));
+
+                if (hostnameConfiguration.keyVaultId) {
+                    hostnameConfiguration.keyVaultId = (await (new BakeVariable(hostnameConfiguration.keyVaultId)).valueAsync(this._ctx));
+                }
+
+                if (hostnameConfiguration.encodedCertificate) {
+                    hostnameConfiguration.encodedCertificate = (await (new BakeVariable(hostnameConfiguration.encodedCertificate)).valueAsync(this._ctx));
+                }
+                
+                if (hostnameConfiguration.certificatePassword) {
+                    hostnameConfiguration.certificatePassword = (await (new BakeVariable(hostnameConfiguration.certificatePassword)).valueAsync(this._ctx));
+                }
 
                 if (hostnameConfiguration.certificate) {
                     hostnameConfiguration.certificate.expiry = (await (new BakeVariable(hostnameConfiguration.certificate.expiry.toString())).valueAsync(this._ctx));


### PR DESCRIPTION
API Management sometimes errors when applying diagnostics via bake

- check existing diagnostics and dont update them if they match
- if new api, add try/catch around to prevent bake from stopping the deployment. The diagnostics still get applied even though APIM throws an "internal error"

