### PR TITLE
fix: Added if_then_variable() coreutil - allows cascading variable va…

### DIFF
--- a/ingredient/ingredient-utils/src/functions.ts
+++ b/ingredient/ingredient-utils/src/functions.ts
@@ -122,6 +122,12 @@ export class CoreUtils extends BaseUtility {
         return await v.valueAsync(this.context);
     }
 
+    public async if_then_variable(key1: string, key2: string, def?: string): Promise<any> {
+        let v: BakeVariable = this._find_variable(key1) || this._find_variable(key2) || new BakeVariable(def || "");
+        return await v.valueAsync(this.context);
+    }
+
+
     public create_region_resource_name(resType: string, name: string | null = null, region: IBakeRegion | null, suffix: string = ""): string {
         let rgn = ""
         if (region)


### PR DESCRIPTION
…lues to use first param first, if not found, try second param, if still not found, use optional default value.