### PR TITLE
fix: apply container filter to all storage account rules

### DIFF
--- a/ingredient/ingredient-storage/src/functions.ts
+++ b/ingredient/ingredient-storage/src/functions.ts
@@ -134,8 +134,18 @@ export class StorageUtils extends BaseUtility {
 
         if (policy)
         {
-            var mgmtClient = new StorageManagementClient(this.context.AuthToken, this.context.Environment.authentication.subscriptionId);
-            var responese = await mgmtClient.managementPolicies.createOrUpdate(account.rg, account.name, policy);    
+            const mgmtClient = new StorageManagementClient(this.context.AuthToken, this.context.Environment.authentication.subscriptionId);
+
+            // ensure the policies are tied to the container via filters
+            if (policy.rules) {
+                for(let i=0; i < policy.rules.length; ++i){
+                    let rule = policy.rules[i]
+                    
+                    rule.definition.filters!.prefixMatch = [container + "/"]
+                }
+            }
+
+            await mgmtClient.managementPolicies.createOrUpdate(account.rg, account.name, policy);    
         }
 
 


### PR DESCRIPTION
Ensure that when adding a policy via the `get_container` method that the policy is scoped to that container via rule filter set. Note this effectively removes the ability to add a rule at the global account level currently, but considering the original intention of these policies were to be at the container level I am omitting that feature for now.