### PR TITLE
Add crypto shim to postgresql ingredient

### DIFF
--- a/ingredient/ingredient-postgresql/src/index.ts
+++ b/ingredient/ingredient-postgresql/src/index.ts
@@ -1,5 +1,48 @@
-import {PostgreSQLDB} from './plugin'
-import {PostgreSQLDBUtils} from './functions'
+// index.ts
+/* eslint-disable @typescript-eslint/no-var-requires */
+
+try {
+  const nodeCrypto = require('crypto');
+  const base: any = nodeCrypto.webcrypto ?? {};
+
+  // Fallback for getRandomValues (some older Node builds)
+  if (typeof base.getRandomValues !== 'function') {
+    base.getRandomValues = (arr: ArrayBufferView) => {
+      nodeCrypto.randomFillSync(arr as unknown as Uint8Array);
+      return arr;
+    };
+  }
+
+  // Provide crypto.randomUUID if Web Crypto doesn't have it
+  if (typeof base.randomUUID !== 'function') {
+    if (typeof nodeCrypto.randomUUID === 'function') {
+      base.randomUUID = () => nodeCrypto.randomUUID();
+    } else {
+      // Pure v4 polyfill using getRandomValues
+      base.randomUUID = () => {
+        const b = new Uint8Array(16);
+        base.getRandomValues(b);
+        b[6] = (b[6] & 0x0f) | 0x40; // version 4
+        b[8] = (b[8] & 0x3f) | 0x80; // variant 10
+        const h = [...b].map(x => x.toString(16).padStart(2, '0')).join('');
+        return `${h.slice(0,8)}-${h.slice(8,12)}-${h.slice(12,16)}-${h.slice(16,20)}-${h.slice(20)}`;
+      };
+    }
+  }
+
+  Object.defineProperty(globalThis, 'crypto', {
+    value: base,
+    writable: false,
+    configurable: true,
+    enumerable: false,
+  });
+  console.log('crypto shimmed!');
+} catch (e) {
+    console.log('No Crypto available:', e);
+}
+
+const { PostgreSQLDB } = require('./plugin');
+const {PostgreSQLDBUtils} = require('./functions');
 
 /*  comment out these entries if you are not including an ingredient plugin runner*/
 exports.plugin = PostgreSQLDB

--- a/ingredient/ingredient-postgresql/src/index.ts
+++ b/ingredient/ingredient-postgresql/src/index.ts
@@ -38,9 +38,10 @@ try {
   });
   console.log('crypto shimmed!');
 } catch (e) {
-    console.log('No Crypto available:', e);
+  console.log('No Crypto available:', e);
 }
 
+// Use require so TS doesn't hoist imports above the shim
 const { PostgreSQLDB } = require('./plugin');
 const {PostgreSQLDBUtils} = require('./functions');
 

--- a/ingredient/ingredient-postgresql/src/index.ts
+++ b/ingredient/ingredient-postgresql/src/index.ts
@@ -43,7 +43,7 @@ try {
 
 // Use require so TS doesn't hoist imports above the shim
 const { PostgreSQLDB } = require('./plugin');
-const {PostgreSQLDBUtils} = require('./functions');
+const { PostgreSQLDBUtils } = require('./functions');
 
 /*  comment out these entries if you are not including an ingredient plugin runner*/
 exports.plugin = PostgreSQLDB


### PR DESCRIPTION
Use PR 330 as a template to update the postgresql ingredient to add the crypto shim.