### PR TITLE
Feature/storage allow public network access 713355

### DIFF
--- a/.github/agents/hchb-code-review-subagent.agent.md
+++ b/.github/agents/hchb-code-review-subagent.agent.md
@@ -1,0 +1,21 @@
+---
+name: hchb-code-review-subagent
+description: "Use when reviewing implementation changes for a checkpoint/phase and returning structured review status: APPROVED, NEEDS_REVISION, or FAILED."
+user-invocable: false
+tools: [read, search]
+---
+You are the HCHB code review subagent.
+
+You perform read-only code review of provided changes.
+
+## Rules
+- Do not edit files.
+- Evaluate correctness, regressions, maintainability, and test adequacy.
+- Use the supplied objective, acceptance criteria, and modified file list.
+
+## Output Format
+Return exactly:
+- Status: APPROVED | NEEDS_REVISION | FAILED
+- Summary: one short paragraph
+- Issues: numbered list with severity (High/Medium/Low), file, and rationale
+- Recommendations: concise actionable list

--- a/.github/agents/hchb-planner-subagent.agent.md
+++ b/.github/agents/hchb-planner-subagent.agent.md
@@ -1,0 +1,57 @@
+---
+name: hchb-planner-subagent
+description: "Use when orchestrating story planning workflows: create plan.md in PLANNING MODE, tasks.md in TASKING MODE, and checkpoints.json in CHECKPOINT MODE for a specific work item."
+user-invocable: false
+tools: [read, search, edit]
+---
+You are the HCHB planner subagent.
+
+You produce planning artifacts for one user story at a time.
+
+## Inputs You Expect
+- Work item context: title, description, acceptance criteria, technical plan (if present), constraints.
+- Mode: `PLANNING MODE`, `TASKING MODE`, or `CHECKPOINT MODE`.
+- Target plan folder path under `.hchbai/plans/<slug>-<work-item-id>/`.
+
+## Global Rules
+- Work only in the current workspace.
+- Do not call external systems unless explicitly instructed.
+- Keep edits scoped to the requested story folder.
+- Use concise, implementation-ready language.
+- If requirements are ambiguous, ask clear clarifying questions.
+
+## Mode Behavior
+
+### PLANNING MODE
+- Create or update only `plan.md` in the target story folder.
+- Build a detailed implementation plan that maps all acceptance criteria to concrete technical steps.
+- Consider repository architecture and existing implementation patterns.
+- Include scope boundaries, risks, assumptions, dependencies, and validation strategy.
+- Do not create or modify `tasks.md` or `checkpoints.json` in this mode.
+
+### TASKING MODE
+- Create or update only `tasks.md` in the target story folder.
+- Read `plan.md` and `test-plan.md` (if present) and generate actionable tasks.
+- Use task codes (e.g., `T001`, `T002`, ...), explicit owners/scope where possible, and clear done criteria.
+- Include implementation and testing tasks.
+- Do not create or modify `plan.md` or `checkpoints.json` in this mode.
+
+### CHECKPOINT MODE
+- Create or update only `checkpoints.json` in the target story folder.
+- Read `tasks.md` and map every task code to exactly one checkpoint.
+- Output must follow this exact schema:
+  {
+    "version": 1,
+    "checkpoints": [
+      { "id": "CP01", "title": "...", "taskCodes": ["T001"] }
+    ]
+  }
+- No extra top-level fields.
+- Do not modify any files except `checkpoints.json` in this mode.
+
+## Output
+- Return a brief summary with:
+  - Mode used
+  - Files created/updated
+  - Coverage status against acceptance criteria (or task mapping status)
+  - Any open questions

--- a/.github/agents/hchb-security-review-subagent.agent.md
+++ b/.github/agents/hchb-security-review-subagent.agent.md
@@ -1,0 +1,21 @@
+---
+name: hchb-security-review-subagent
+description: "Use when reviewing checkpoint/phase changes for security vulnerabilities and returning structured status: APPROVED, NEEDS_REVISION, or FAILED."
+user-invocable: false
+tools: [read, search]
+---
+You are the HCHB security review subagent.
+
+You perform read-only security review of provided changes.
+
+## Rules
+- Do not edit files.
+- Evaluate input validation, authn/authz assumptions, data exposure, secrets handling, dependency risk, and unsafe defaults.
+- Use the supplied objective, acceptance criteria, and modified file list.
+
+## Output Format
+Return exactly:
+- Status: APPROVED | NEEDS_REVISION | FAILED
+- Summary: one short paragraph
+- Issues: numbered list with severity (High/Medium/Low), file, and exploit/risk rationale
+- Remediations: concise actionable list

--- a/.github/agents/hchb-test-plan-subagent.agent.md
+++ b/.github/agents/hchb-test-plan-subagent.agent.md
@@ -1,0 +1,33 @@
+---
+name: hchb-test-plan-subagent
+description: "Use when creating or updating story-level test-plan.md mapped to acceptance criteria, including scenario tracking level classification (ADO or repoOnly)."
+user-invocable: false
+tools: [read, search, edit]
+---
+You are the HCHB test plan subagent.
+
+You create comprehensive test plans for a single user story.
+
+## Inputs You Expect
+- Work item context: title, description, acceptance criteria, technical plan (if present), constraints.
+- Story folder under `.hchbai/plans/<slug>-<work-item-id>/`.
+- Any discussion-summary context from comments.
+
+## Rules
+- Create or update only `test-plan.md` in the target story folder.
+- Follow your internal canonical test-plan schema.
+- Map each relevant runtime-behavior acceptance criterion to concrete scenarios.
+- Exclude acceptance criteria that are only about artifact existence, architecture conventions, or review process checklists.
+- Classify every scenario with Tracking Level:
+  - `repoOnly` for Unit and Component scenarios.
+  - `ADO` for backend integration/API/GraphQL and UI E2E scenarios that hit backend services.
+  - If uncertain, default to `repoOnly` and document rationale.
+- Include manual/automated guidance, test data, environment setup, entry/exit criteria.
+- Ask clarifying questions if requirements are ambiguous.
+
+## Output
+- Return a concise summary with:
+  - File updated
+  - AC-to-scenario coverage summary
+  - Tracking Level distribution
+  - Open questions/risks

--- a/.hchbai/plans/storage-allow-public-network-access-713355/checkpoints.json
+++ b/.hchbai/plans/storage-allow-public-network-access-713355/checkpoints.json
@@ -1,0 +1,30 @@
+{
+  "version": 1,
+  "checkpoints": [
+    {
+      "id": "CP01",
+      "title": "Baseline Analysis and Constants Setup",
+      "taskCodes": ["T001", "T002"]
+    },
+    {
+      "id": "CP02",
+      "title": "Input Handling and Deployment Parameter Safety",
+      "taskCodes": ["T003", "T004"]
+    },
+    {
+      "id": "CP03",
+      "title": "Template Tag Mutation and Pass-1 Guardrails",
+      "taskCodes": ["T005", "T006"]
+    },
+    {
+      "id": "CP04",
+      "title": "Automated Validation Coverage",
+      "taskCodes": ["T007", "T008"]
+    },
+    {
+      "id": "CP05",
+      "title": "Documentation and Final Verification Evidence",
+      "taskCodes": ["T009", "T010"]
+    }
+  ]
+}

--- a/.hchbai/plans/storage-allow-public-network-access-713355/plan.md
+++ b/.hchbai/plans/storage-allow-public-network-access-713355/plan.md
@@ -1,0 +1,157 @@
+# Work Item 713355 Plan
+
+## Story
+Storage Ingredient > Add allowPublicNetworkAccess boolean (Pass 1 stub) + public-network exception tag + tag-assertion tests
+
+## Planning Mode Scope
+Implement pass-1, tag-only behavior for storage public network access signaling.
+
+In scope:
+- Accept optional `allowPublicNetworkAccess` input in storage ingredient flow.
+- Stamp tag `allow-public-network-access=true` only when input is true.
+- Do not emit `publicNetworkAccess` ARM property in this pass.
+- Store public-network tag name/value as Bake constants.
+- Preserve existing tags (including `Metrics`) and support co-existence with sibling anonymous-blob tag behavior.
+- Add deployment test coverage for tag assertions across representative combinations.
+- Update storage ingredient README documentation.
+
+Out of scope:
+- Any storage account `apiVersion` change.
+- Any ARM template `publicNetworkAccess` property introduction.
+- Any behavior change that enforces network policy directly in ARM for this story.
+
+## Current Repo Findings (Read-Only)
+- Storage deployment entrypoint is `ingredient/ingredient-storage/src/plugin.ts`.
+- Storage ARM templates are:
+  - `ingredient/ingredient-storage/src/storage.json`
+  - `ingredient/ingredient-storage/src/storageNetwork.json`
+  - `ingredient/ingredient-storage/src/storageDatalake.json`
+- Templates currently include a static `Metrics: *` tag on the storage account resource.
+- No current `allowPublicNetworkAccess` or `publicNetworkAccess` handling exists in storage ingredient.
+- ARM helper appends standard Bake tags by merging onto resource tags, so story-specific tags must be preserved in the template object prior to deployment.
+- Existing storage test assets are integration-style under `ingredient/ingredient-storage/test/` (recipe plus run scripts), not unit tests.
+
+## Acceptance Criteria Mapping
+
+### AC1: Accept optional allowPublicNetworkAccess boolean; pass 1 must never emit publicNetworkAccess ARM property
+Implementation plan:
+1. Add optional parsing in `ingredient/ingredient-storage/src/plugin.ts` for `params['allowPublicNetworkAccess']`.
+2. Normalize to boolean with safe coercion for Bake values (`true`/`false` booleans and string equivalents) and treat omitted as undefined.
+3. Immediately remove `allowPublicNetworkAccess` from ARM params before `DeployTemplate` calls to avoid undeclared-parameter validation failures.
+4. Do not add `publicNetworkAccess` to any storage ARM template (`storage.json`, `storageNetwork.json`, `storageDatalake.json`).
+5. Add regression validation steps in tests to assert deployed storage account does not contain `publicNetworkAccess` due to this story logic.
+
+### AC2: If true, stamp allow-public-network-access=true tag
+Implementation plan:
+1. Introduce constants for the tag key/value (see AC4).
+2. In `plugin.ts`, when normalized `allowPublicNetworkAccess === true`, create extra tag map with the constant key/value.
+3. Apply tag map to whichever template is selected (`ARMTemplate`, `ARMTemplateNetwork`, `ARMTemplateDataLake`) before deployment.
+
+### AC3: If false/omitted, stamp no tag and write no property
+Implementation plan:
+1. If normalized value is false or undefined, do not add the story tag.
+2. Keep template tags unchanged except existing tags already present.
+3. Ensure `allowPublicNetworkAccess` parameter is still removed from ARM params in all cases.
+
+### AC4: Tag name/value stored as Bake constant
+Implementation plan:
+1. Add a new constants module for storage ingredient, for example `ingredient/ingredient-storage/src/constants.ts`.
+2. Define exported constants:
+   - Public network tag name: `allow-public-network-access`
+   - Public network tag value: `true`
+3. Import and use these constants in `plugin.ts` tag composition logic (avoid inline literals).
+
+### AC5: Preserve Metrics tag and co-exist with allow-anonymous-blob-access
+Implementation plan:
+1. Implement a targeted tag merge helper in `plugin.ts` that:
+   - Locates `Microsoft.Storage/storageAccounts` resource in the selected template object.
+   - Merges new story tags with existing `resource.tags` rather than replacing the tag object.
+2. Guarantee existing `Metrics` tag survives unchanged.
+3. Merge behavior must be additive so any existing anonymous-blob tag (for example `allow-anonymous-blob-access`) remains when present.
+4. Prefer immutable template handling (clone imported template object before mutation) to prevent cross-run tag leakage between deployments.
+
+### AC6: Add tag-assertion deployment tests for representative combinations
+Implementation plan:
+1. Add storage integration test recipes under `ingredient/ingredient-storage/test/` for representative combinations:
+   - Case A: `allowPublicNetworkAccess: true`.
+   - Case B: `allowPublicNetworkAccess: false`.
+   - Case C: omitted `allowPublicNetworkAccess`.
+   - Case D: co-existence scenario with anonymous-blob public access behavior (if supported on branch).
+2. Add/extend test runner scripts (`run.ps1` and optionally `run.sh`) to:
+   - Deploy each case.
+   - Query resulting storage account tags.
+   - Assert expected tag presence/absence.
+   - Assert no `publicNetworkAccess` property was introduced by this story path.
+3. Keep assertions deterministic and fail-fast with clear output per case.
+
+### AC7: README documents parameter and pass-1 semantics
+Implementation plan:
+1. Update `ingredient/ingredient-storage/README.md` parameter table with `allowPublicNetworkAccess`.
+2. Document pass-1 behavior explicitly:
+   - Parameter is optional and tag-only in this story.
+   - When true, tag is stamped.
+   - When false/omitted, no tag is stamped.
+   - No ARM `publicNetworkAccess` property is written in pass 1.
+3. Add a concise YAML example showing usage.
+
+## Detailed Implementation Steps
+1. Add storage constants module and export story tag constants.
+2. In storage plugin, parse and normalize `allowPublicNetworkAccess` from Bake params.
+3. Remove `allowPublicNetworkAccess` from `params` prior to any `DeployTemplate` call.
+4. Clone selected ARM template object before mutation.
+5. Merge story tag (conditional) into storage account resource tags using additive merge logic.
+6. Deploy cloned template object (existing deployment flow remains otherwise unchanged).
+7. Add integration-style tag assertion test cases and runner assertions.
+8. Update README parameter docs and pass-1 explanation.
+9. Run compile and targeted storage test execution for validation.
+
+## Validation Strategy
+Code-level validation:
+- Compile `ingredient-storage` TypeScript after changes.
+- Verify no TS errors introduced.
+
+Behavior validation (deployment/integration):
+- Execute storage test cases for true/false/omitted combinations.
+- Assert tags:
+  - `allow-public-network-access=true` only for true case.
+  - Tag absent for false and omitted cases.
+  - `Metrics=*` remains in all cases.
+  - Co-existence case retains anonymous-blob tag and public-network tag simultaneously where applicable.
+- Assert `publicNetworkAccess` is not present in deployed resource properties for pass-1 scenarios.
+
+Regression validation:
+- Confirm no template `apiVersion` changes.
+- Confirm no `publicNetworkAccess` property additions in storage ARM JSON templates.
+- Confirm existing deploy paths (default, network ACL, data lake) remain functional.
+
+## Dependencies
+- Access to Azure test subscription/service principal for deployment assertions.
+- Existing storage test harness under `ingredient/ingredient-storage/test/`.
+- Any sibling anonymous-blob tag behavior expected by co-existence scenario (if in same branch scope).
+
+## Assumptions
+- `allowPublicNetworkAccess` is provided as a parameter under storage ingredient `properties.parameters`.
+- Deployment tests in this repo are integration-style and can be extended with script assertions instead of introducing a new unit test framework.
+- Co-existence with anonymous-blob tag means additive merge and no overwrites; if the tag is not produced in this branch, co-existence will be validated by non-destructive merge logic and representative test fixture support.
+
+## Risks and Mitigations
+- Risk: Extra undeclared ARM parameter causes deployment validation failure.
+  - Mitigation: Always delete `allowPublicNetworkAccess` from ARM params before deployment.
+- Risk: Mutating imported JSON templates leaks tags across runs.
+  - Mitigation: Deep-clone selected template before applying story tags.
+- Risk: Tag merge accidentally overwrites existing tags.
+  - Mitigation: Additive merge helper with explicit preservation checks for `Metrics` and existing keys.
+- Risk: Boolean coercion inconsistency from Bake variable typing.
+  - Mitigation: Centralized normalization logic and test cases for bool/string inputs.
+
+## Scope Boundaries
+- No apiVersion upgrades in storage ARM templates.
+- No implementation of ARM-level `publicNetworkAccess` toggling.
+- No unrelated refactors in storage diagnostics, upload flow, or alert deployment.
+
+## Definition of Done (Plan Exit Criteria)
+- All 7 acceptance criteria are implemented and validated.
+- Storage templates retain current apiVersion values.
+- No `publicNetworkAccess` property is emitted by this story changeset.
+- Tag behavior verified for true/false/omitted and co-existence scenario.
+- README updated with pass-1 semantics and usage example.

--- a/.hchbai/plans/storage-allow-public-network-access-713355/tasks.md
+++ b/.hchbai/plans/storage-allow-public-network-access-713355/tasks.md
@@ -25,7 +25,7 @@ Implement pass-1 support for optional `allowPublicNetworkAccess` in Storage ingr
 1. Tag key/value are sourced from constants only.
 2. No duplicated hard-coded tag literals remain in updated storage plugin path.
 
-### T003 — Implement optional input normalization for allowPublicNetworkAccess
+### [x] T003 — Implement optional input normalization for allowPublicNetworkAccess
 - Owner/Scope: Storage ingredient implementation
 - Actions:
 1. Parse `allowPublicNetworkAccess` as optional input from ingredient parameters.
@@ -35,7 +35,7 @@ Implement pass-1 support for optional `allowPublicNetworkAccess` in Storage ingr
 1. True/false/omitted branches are explicit in code.
 2. Invalid input behavior is deterministic and testable.
 
-### T004 — Strip allowPublicNetworkAccess from ARM params payload
+### [x] T004 — Strip allowPublicNetworkAccess from ARM params payload
 - Owner/Scope: Storage ingredient implementation
 - Actions:
 1. Ensure `allowPublicNetworkAccess` is removed from params passed to ARM deploy calls in all template branches.

--- a/.hchbai/plans/storage-allow-public-network-access-713355/tasks.md
+++ b/.hchbai/plans/storage-allow-public-network-access-713355/tasks.md
@@ -1,0 +1,135 @@
+# Tasks — Work Item 713355
+
+## Scope
+Implement pass-1 support for optional `allowPublicNetworkAccess` in Storage ingredient as tag-only behavior, with no ARM `publicNetworkAccess` property emission and no API version changes.
+
+## Task List
+
+### [x] T001 — Baseline storage ingredient flow and template branch points
+- Owner/Scope: Storage ingredient implementation
+- Actions:
+1. Review `ingredient/ingredient-storage/src/plugin.ts` deploy path selection (default/network/datalake templates).
+2. Identify where ingredient parameters are read and where params are passed to `DeployTemplate`.
+3. Confirm storage account resource tag structure in all three templates.
+- Done Criteria:
+1. Concrete edit points are identified for parameter normalization, param stripping, and tag merge.
+2. No code changes made outside storage ingredient scope.
+
+### [x] T002 — Add constants for public-network tag key/value
+- Owner/Scope: Storage ingredient implementation
+- Actions:
+1. Add storage constants module (or extend existing constant location) under `ingredient/ingredient-storage/src/`.
+2. Define exported constants for tag name `allow-public-network-access` and tag value `true`.
+3. Replace inline literals in plugin logic with constants.
+- Done Criteria:
+1. Tag key/value are sourced from constants only.
+2. No duplicated hard-coded tag literals remain in updated storage plugin path.
+
+### T003 — Implement optional input normalization for allowPublicNetworkAccess
+- Owner/Scope: Storage ingredient implementation
+- Actions:
+1. Parse `allowPublicNetworkAccess` as optional input from ingredient parameters.
+2. Normalize supported boolean forms used by Bake inputs (boolean values; string forms if contract allows).
+3. Define deterministic behavior for invalid types/unsupported values and surface a clear error if rejected.
+- Done Criteria:
+1. True/false/omitted branches are explicit in code.
+2. Invalid input behavior is deterministic and testable.
+
+### T004 — Strip allowPublicNetworkAccess from ARM params payload
+- Owner/Scope: Storage ingredient implementation
+- Actions:
+1. Ensure `allowPublicNetworkAccess` is removed from params passed to ARM deploy calls in all template branches.
+2. Verify no undeclared parameter can reach template deployment.
+- Done Criteria:
+1. Deployment parameter object does not include `allowPublicNetworkAccess` in any branch.
+2. Existing unrelated params continue passing through unchanged.
+
+### T005 — Implement additive tag merge on selected storage template
+- Owner/Scope: Storage ingredient implementation
+- Actions:
+1. Clone selected template object before mutation to prevent cross-run leakage.
+2. Locate `Microsoft.Storage/storageAccounts` resource and merge tags additively.
+3. Add `allow-public-network-access=true` only when normalized input is true.
+4. Preserve existing tags (including `Metrics`) and co-exist with pre-existing sibling tags such as `allow-anonymous-blob-access`.
+- Done Criteria:
+1. True path adds only the expected tag key/value.
+2. False/omitted paths do not add the tag.
+3. Existing tags are preserved and not overwritten.
+
+### T006 — Guard pass-1 constraint: never emit publicNetworkAccess and never bump apiVersion
+- Owner/Scope: Storage ingredient implementation
+- Actions:
+1. Ensure no code path injects `publicNetworkAccess` into any storage ARM template object.
+2. Confirm no edits introduce API version changes in `storage.json`, `storageNetwork.json`, or `storageDatalake.json`.
+- Done Criteria:
+1. `publicNetworkAccess` is absent from story changes.
+2. Storage template API versions remain unchanged.
+
+### T007 — Add/extend repo-local tests for normalization and template mutation behavior
+- Owner/Scope: Storage ingredient test code (repo-only)
+- Actions:
+1. Add tests (or equivalent harness assertions) covering DS1/DS2/DS3 and optional DS4/DS5 normalization behavior from test plan.
+2. Assert param stripping, tag outcomes, and absence of `publicNetworkAccess` in mutated template object.
+3. Add invalid input test (DS7) consistent with chosen validation contract.
+- Done Criteria:
+1. Automated repo-local assertions validate true/false/omitted outcomes.
+2. Tests explicitly verify no `publicNetworkAccess` property is introduced.
+3. Invalid input behavior is covered by assertion.
+
+### T008 — Add deployment tag-assertion cases in storage integration harness
+- Owner/Scope: Storage integration tests
+- Actions:
+1. Add representative deployment cases for true, false, omitted, and co-existence scenario in `ingredient/ingredient-storage/test/`.
+2. Update run script assertions to query deployed storage account tags/properties.
+3. Assert exact expected tag map per case and absence of `publicNetworkAccess` in deployed resource properties.
+- Done Criteria:
+1. Integration harness can execute all representative combinations.
+2. Each case has deterministic pass/fail assertions with clear output.
+3. Co-existence case verifies additive tag behavior.
+
+### T009 — Update storage README for parameter and pass-1 semantics
+- Owner/Scope: Documentation
+- Actions:
+1. Add `allowPublicNetworkAccess` to README parameter documentation as optional.
+2. Document pass-1 semantics: tag-only behavior, tag stamped only when true, none when false/omitted.
+3. Explicitly document that ARM `publicNetworkAccess` is not written in this pass.
+4. Add concise usage example.
+- Done Criteria:
+1. README reflects implemented behavior and constraints.
+2. Example aligns with accepted input contract.
+
+### T010 — Execute validation and capture evidence
+- Owner/Scope: Validation
+- Actions:
+1. Run storage ingredient build/tests required for changed code paths.
+2. Run storage integration harness for representative combinations when Azure credentials are available.
+3. Collect assertion outputs showing tag expectations and no `publicNetworkAccess` property.
+- Done Criteria:
+1. Repo-local tests pass for changed behavior.
+2. Integration evidence is captured or blocked status is recorded with reason.
+3. Final verification notes map outcomes to AC1-AC7.
+
+## Sequencing and Dependencies
+1. T001
+2. T002, T003
+3. T004, T005
+4. T006
+5. T007
+6. T008
+7. T009
+8. T010
+
+## Acceptance Criteria Coverage Matrix
+| AC | Covered By | Coverage Notes |
+|---|---|---|
+| AC1 Optional input; no `publicNetworkAccess` | T003, T004, T006, T007, T008 | Input handling + param stripping + no-property assertions |
+| AC2 Tag when true | T002, T005, T007, T008 | Constant-backed true-path tag stamping |
+| AC3 No tag when false/omitted | T003, T005, T007, T008 | Branch assertions for false and omitted |
+| AC4 Constant for tag name/value | T002 | Centralized constants usage |
+| AC5 Preserve `Metrics` and co-existence | T005, T007, T008 | Additive merge + co-existence assertions |
+| AC6 Tag-assertion deployment tests | T008, T010 | Representative deployment matrix + evidence |
+| AC7 README updates | T009 | Parameter + pass-1 semantics documented |
+
+## Notes
+- This task set intentionally excludes creating ADO work items.
+- This task set preserves story constraints: no API version bump and no ARM `publicNetworkAccess` property in this pass.

--- a/.hchbai/plans/storage-allow-public-network-access-713355/test-plan.md
+++ b/.hchbai/plans/storage-allow-public-network-access-713355/test-plan.md
@@ -1,0 +1,195 @@
+# Test Plan: Work Item 713355
+
+## Story Under Test
+- Work Item: 713355
+- Title: Storage Ingredient > Add allowPublicNetworkAccess boolean (Pass 1 stub) + public-network exception tag + tag-assertion tests
+- Pass Scope: Pass 1 tag-only behavior for storage public network access signaling
+
+## Objectives
+- Verify runtime behavior for optional `allowPublicNetworkAccess` handling in the storage ingredient.
+- Verify pass-1 constraints: no emitted `publicNetworkAccess` ARM property for any input.
+- Verify exact tag outcomes, including preservation of existing `Metrics` tag and additive co-existence behavior.
+
+## Runtime Scope
+- In scope runtime behavior:
+- `allowPublicNetworkAccess=true` stamps `allow-public-network-access=true` tag.
+- `allowPublicNetworkAccess=false` or omitted stamps no public-network tag.
+- Deployed storage account does not include `publicNetworkAccess` property.
+- Existing tags remain intact, specifically `Metrics`, and can co-exist with sibling tags.
+- Representative deployment combinations assert exact resulting tag set.
+
+## Non-Runtime Coverage Notes
+- AC4 (constant ownership of tag name/value) is implementation-contract verification, not runtime behavior.
+- AC7 (README updates) is documentation verification, not runtime behavior.
+- These are excluded from runtime scenario tracking and should be validated in code review/checklist.
+
+## Entry Criteria
+- Story implementation for `ingredient/ingredient-storage/src/plugin.ts` is present on test branch.
+- Storage templates remain in current repo locations and deploy path is functional:
+- `ingredient/ingredient-storage/src/storage.json`
+- `ingredient/ingredient-storage/src/storageNetwork.json`
+- `ingredient/ingredient-storage/src/storageDatalake.json`
+- Test credentials are available for deployment validation:
+- `BAKE_AUTH_SUBSCRIPTION_ID`
+- `BAKE_AUTH_TENANT_ID`
+- `BAKE_AUTH_SERVICE_ID`
+- `BAKE_AUTH_SERVICE_KEY`
+- Optional image push target if needed by harness: `CONTAINER_URI`.
+
+## Exit Criteria
+- All runtime scenarios marked Pass.
+- AC1, AC2, AC3, AC5, and AC6 each have at least one passing scenario.
+- No failing evidence of `publicNetworkAccess` in deployed resource properties.
+- Exact tag assertions pass for true/false/omitted/co-existence representative cases.
+
+## Environment and Setup
+- Repo root with dependencies installed and ingredient packages buildable.
+- Storage harness entrypoint available: `ingredient/ingredient-storage/test/run.ps1`.
+- Baseline recipe available: `ingredient/ingredient-storage/test/test.yaml`.
+- Azure subscription with permission to deploy resource groups and storage accounts.
+
+## Test Data Matrix
+| Data Set | allowPublicNetworkAccess Input | Additional Inputs | Expected Tags on Storage Account | Expected Property Outcome |
+|---|---|---|---|---|
+| DS1 | `true` (boolean) | none | `Metrics=*`, `allow-public-network-access=true` | No `publicNetworkAccess` property |
+| DS2 | `false` (boolean) | none | `Metrics=*` only | No `publicNetworkAccess` property |
+| DS3 | omitted | none | `Metrics=*` only | No `publicNetworkAccess` property |
+| DS4 | `"true"` (string) if accepted normalization path exists | none | same as DS1 | No `publicNetworkAccess` property |
+| DS5 | `"false"` (string) if accepted normalization path exists | none | same as DS2 | No `publicNetworkAccess` property |
+| DS6 | `true` | co-existence fixture includes `allow-anonymous-blob-access=true` | `Metrics=*`, `allow-public-network-access=true`, `allow-anonymous-blob-access=true` | No `publicNetworkAccess` property |
+| DS7 | invalid type (for example `1`, `{}`) | none | deployment blocked or explicit validation failure | No deployment with mutated network property |
+
+## AC to Scenario Mapping
+| Acceptance Criterion | Runtime Relevant | Covered By Scenarios | Notes |
+|---|---|---|---|
+| AC1: Optional boolean accepted; pass-1 must not emit `publicNetworkAccess` | Yes | S1, S2, S3, S6 | Includes no-property verification for every branch |
+| AC2: True stamps `allow-public-network-access=true` | Yes | S3, S6 | Exact tag assertion required |
+| AC3: False/omitted produce no tag and no property | Yes | S4, S6 | Exact tag assertion required |
+| AC4: Tag key/value as Bake constant | No | Excluded from runtime scenarios | Verify via code review/static check |
+| AC5: Metrics preserved; co-exists with anonymous-blob tag | Yes | S5, S6 | Additive merge behavior |
+| AC6: Deployment tag-assertion test with representative combinations | Yes | S6 | Integration matrix is primary acceptance evidence |
+| AC7: README documents parameter and semantics | No | Excluded from runtime scenarios | Verify via doc review/static check |
+
+## Scenario Catalog
+
+### S1 - Parameter normalization and pass-through stripping
+- Tracking Level: `repoOnly`
+- Test Type: Unit
+- AC Coverage: AC1
+- Automation: Automated
+- Purpose: Validate optional parameter handling and that `allowPublicNetworkAccess` does not remain in ARM params payload.
+- Preconditions: Unit test harness can invoke plugin parameter normalization path.
+- Steps:
+1. Execute plugin path with DS1, DS2, DS3, DS4, DS5 inputs.
+2. Capture resulting deployment params object prior to `DeployTemplate` call.
+3. Assert `allowPublicNetworkAccess` key is removed for each input.
+- Expected Results:
+1. Boolean and supported string forms normalize consistently.
+2. ARM params payload does not contain `allowPublicNetworkAccess`.
+3. No logic introduces `publicNetworkAccess` property into template properties.
+
+### S2 - Invalid type validation behavior
+- Tracking Level: `repoOnly`
+- Test Type: Unit
+- AC Coverage: AC1
+- Automation: Automated
+- Purpose: Ensure non-boolean unsupported input types are rejected or handled deterministically per implementation contract.
+- Preconditions: Validation logic implemented for parameter type checking.
+- Steps:
+1. Execute plugin path with DS7 values.
+2. Observe thrown error or defined failure response.
+3. Confirm no deploy call is made with malformed parameter.
+- Expected Results:
+1. Invalid types fail with explicit actionable error.
+2. No ARM deployment mutation occurs.
+
+### S3 - True path tag stamping and no network property mutation
+- Tracking Level: `repoOnly`
+- Test Type: Component
+- AC Coverage: AC1, AC2
+- Automation: Automated
+- Purpose: Verify true-path tag injection into selected storage template while preserving existing tags and not adding `publicNetworkAccess`.
+- Preconditions: Component test can inspect mutated template object before deployment.
+- Steps:
+1. Run plugin execution path with DS1 and default template branch.
+2. Inspect storage account resource tags in deployed template object.
+3. Inspect storage account resource properties object.
+- Expected Results:
+1. Tags include `Metrics=*` and `allow-public-network-access=true`.
+2. `publicNetworkAccess` is absent from resource properties.
+
+### S4 - False and omitted path no-op behavior
+- Tracking Level: `repoOnly`
+- Test Type: Component
+- AC Coverage: AC1, AC3
+- Automation: Automated
+- Purpose: Verify false and omitted inputs do not stamp new public-network tag and do not mutate network property.
+- Preconditions: Same as S3.
+- Steps:
+1. Run plugin execution path with DS2 and DS3.
+2. Inspect resulting storage account tags.
+3. Inspect storage account properties.
+- Expected Results:
+1. Tags remain `Metrics=*` only.
+2. `allow-public-network-access` tag is absent.
+3. `publicNetworkAccess` property is absent.
+
+### S5 - Tag co-existence and preservation
+- Tracking Level: `repoOnly`
+- Test Type: Component
+- AC Coverage: AC5
+- Automation: Automated
+- Purpose: Confirm additive merge semantics preserve existing tags and support sibling tag co-existence.
+- Preconditions: Fixture/template includes `allow-anonymous-blob-access=true` tag prior to merge, or equivalent branch behavior is simulated.
+- Steps:
+1. Execute true-path tagging with DS6 fixture.
+2. Inspect resulting tag map.
+3. Compare against expected exact set.
+- Expected Results:
+1. `Metrics=*` preserved.
+2. `allow-anonymous-blob-access=true` preserved.
+3. `allow-public-network-access=true` present.
+4. No existing tag keys are removed or overwritten unexpectedly.
+
+### S6 - Deployment tag-assertion matrix (representative combinations)
+- Tracking Level: `ADO`
+- Test Type: Integration (deployment)
+- AC Coverage: AC1, AC2, AC3, AC5, AC6
+- Automation: Automated preferred, manual fallback supported
+- Purpose: Validate end-to-end deployed resource tag set and no-property guarantee across representative combinations.
+- Preconditions:
+1. Azure deployment credentials configured.
+2. Test recipes/cases available for DS1, DS2, DS3, DS6.
+3. Harness can query deployed storage account tags and properties after deployment.
+- Steps:
+1. Deploy representative cases through storage test harness.
+2. For each case, query storage account tags and properties from Azure.
+3. Assert exact tag set equality for each data set.
+4. Assert `publicNetworkAccess` property does not exist in deployed resource for all cases.
+5. Record result artifacts per case (deployment output, queried JSON, assertion log).
+- Expected Results:
+1. DS1 exact tags: `Metrics=*`, `allow-public-network-access=true`.
+2. DS2 exact tags: `Metrics=*` only.
+3. DS3 exact tags: `Metrics=*` only.
+4. DS6 exact tags include all three expected tags with correct values.
+5. No case includes deployed `publicNetworkAccess` property.
+
+## Automation and Manual Guidance
+- Unit and component scenarios (S1-S5) should run in repo CI as `repoOnly` checks.
+- Integration scenario (S6) should run in ADO pipeline/stage that has Azure credentials and cleanup controls.
+- If ADO automation is unavailable, execute S6 manually with `ingredient/ingredient-storage/test/run.ps1` and explicit post-deploy ARM queries; retain evidence logs and resource snapshots.
+
+## Evidence Requirements
+- Unit/component run output with passing assertions for S1-S5.
+- Deployment logs and queried storage account JSON for each S6 case.
+- Explicit assertion evidence that `publicNetworkAccess` is absent in all S6 case outputs.
+- Exact tag map assertion output for each representative case.
+
+## Tracking Level Distribution
+- `repoOnly`: 5 scenarios (S1-S5)
+- `ADO`: 1 scenario (S6)
+- Rationale: Only end-to-end Azure deployment validation hits backend services; all unit/component checks remain repository-local.
+
+## Risks and Open Questions
+- Co-existence fixture dependency: If sibling `allow-anonymous-blob-access` behavior is not present on branch, S5/S6 DS6 must use a controlled fixture to simulate pre-existing tag state.
+- Validation contract detail: If implementation chooses coercion vs strict rejection for string forms, DS4/DS5 expectations should be finalized to match code contract before execution.

--- a/ingredient/ingredient-storage/src/constants.ts
+++ b/ingredient/ingredient-storage/src/constants.ts
@@ -1,0 +1,2 @@
+export const ALLOW_PUBLIC_NETWORK_ACCESS_TAG_KEY = "allow-public-network-access"
+export const ALLOW_PUBLIC_NETWORK_ACCESS_TAG_VALUE = "true"

--- a/ingredient/ingredient-storage/src/plugin.ts
+++ b/ingredient/ingredient-storage/src/plugin.ts
@@ -7,6 +7,7 @@ import { StorageUtils } from "./functions.js";
 import { StorageSharedKeyCredential, BlobServiceClient, ContainerClient } from "@azure/storage-blob"
 import ARMTemplateNetwork from "./storageNetwork.json"
 import ARMTemplateDataLake from "./storageDatalake.json"
+import { ALLOW_PUBLIC_NETWORK_ACCESS_TAG_KEY, ALLOW_PUBLIC_NETWORK_ACCESS_TAG_VALUE } from "./constants"
 import * as fs from 'fs';
 
 const path = require("path")
@@ -14,6 +15,9 @@ const path = require("path")
 export class StoragePlugIn extends BaseIngredient {
     
     private resourceGroup: string = ""
+    private readonly allowPublicNetworkAccessTag: Readonly<Record<string, string>> = {
+        [ALLOW_PUBLIC_NETWORK_ACCESS_TAG_KEY]: ALLOW_PUBLIC_NETWORK_ACCESS_TAG_VALUE
+    }
 
     public async Execute(): Promise<void> {
         try {
@@ -49,6 +53,9 @@ export class StoragePlugIn extends BaseIngredient {
             // begin deployment
             if(deploy) 
             {
+                // CP01 baseline: constants are wired for upcoming template tag merge work.
+                this._logger.debug(`public-network tag constant: ${Object.keys(this.allowPublicNetworkAccessTag)[0]}=${this.allowPublicNetworkAccessTag[ALLOW_PUBLIC_NETWORK_ACCESS_TAG_KEY]}`)
+
                 if(params['NetworkAcls'])
                 {
                     await helper.DeployTemplate(this._name, ARMTemplateNetwork, params, this.resourceGroup)

--- a/ingredient/ingredient-storage/src/plugin.ts
+++ b/ingredient/ingredient-storage/src/plugin.ts
@@ -19,6 +19,33 @@ export class StoragePlugIn extends BaseIngredient {
         [ALLOW_PUBLIC_NETWORK_ACCESS_TAG_KEY]: ALLOW_PUBLIC_NETWORK_ACCESS_TAG_VALUE
     }
 
+    private async normalizeOptionalAllowPublicNetworkAccess(): Promise<boolean | undefined> {
+        const allowPublicNetworkAccessParam = this._ingredient.properties.parameters.get("allowPublicNetworkAccess")
+        if (!allowPublicNetworkAccessParam) {
+            return undefined
+        }
+
+        const rawValue = await allowPublicNetworkAccessParam.valueAsync(this._ctx)
+        if (typeof rawValue === "boolean") {
+            return rawValue
+        }
+
+        if (typeof rawValue === "string") {
+            const normalizedString = rawValue.trim().toLowerCase()
+            if (normalizedString === "true") {
+                return true
+            }
+
+            if (normalizedString === "false") {
+                return false
+            }
+
+            throw new Error("Parameter 'allowPublicNetworkAccess' must be one of: true, false, 'true', or 'false'.")
+        }
+
+        throw new Error("Parameter 'allowPublicNetworkAccess' must be one of: true, false, 'true', or 'false'.")
+    }
+
     public async Execute(): Promise<void> {
         try {
             let util = IngredientManager.getIngredientFunction("coreutils", this._ctx)
@@ -27,6 +54,11 @@ export class StoragePlugIn extends BaseIngredient {
             const helper = new ARMHelper(this._ctx);
             
             let params = await helper.BakeParamsToARMParamsAsync(this._name, this._ingredient.properties.parameters)
+
+            const normalizedAllowPublicNetworkAccess = await this.normalizeOptionalAllowPublicNetworkAccess()
+            if (normalizedAllowPublicNetworkAccess !== undefined) {
+                this._logger.debug(`allowPublicNetworkAccess normalized to '${normalizedAllowPublicNetworkAccess}'.`)
+            }
             
             // define resource group
             let rgOverrideParam  = this._ingredient.properties.parameters.get('rgOverride')
@@ -49,6 +81,7 @@ export class StoragePlugIn extends BaseIngredient {
             delete params["container"]
             delete params["uploadPath"]
             delete params["unzip"]
+            delete params["allowPublicNetworkAccess"]
 
             // begin deployment
             if(deploy) 


### PR DESCRIPTION
As a Bake recipe author, I want to declare an approved public-network-access exception via an optional allowPublicNetworkAccess boolean that stamps the matching exception tag now — without changing any network behavior yet — so my storage repos can be edited once against the final contract, and my CDN-style accounts are pre-exempt when the deny policies flip to Deny.

Context
This is the forward-compatible stub half of the storage public-access work. publicNetworkAccess: Disabled requires NetOps-owned private DNS resolution (Feature 701425) that does not exist yet — setting it early would sever connectivity. So in Pass 1 this parameter is captured and tag-stamped only; the actual property (and private endpoints) is wired later in Feature 698027, behind the DNS gate, with no further recipe edit required.

Stamping the exception tag now is the point: the 16 CDN accounts (Feature 701421) get allow-public-network-access = true immediately so they are already exempt when Feature 704176 flips its deny policy from audit to Deny, even though private-endpoint enforcement has not happened.