### PR TITLE
refactor(property-service): centralize canonical secret name helpers in coreutils

### DIFF
--- a/ingredient/ingredient-cosmosdb/src/functions.ts
+++ b/ingredient/ingredient-cosmosdb/src/functions.ts
@@ -17,21 +17,6 @@ export class CosmosUtility extends BaseUtility {
         return name;
     }
 
-    // Environment-independent Property Service secret name for a cosmos account connection
-    // string. The account's region code is retained so per-region accounts (active/active or
-    // active/passive) map to distinct secrets rather than colliding on a single name.
-    public get_connectionstring_property_name(account: string): string {
-        let util = IngredientManager.getIngredientFunction("coreutils", this.context);
-        return util.canonical_resource_name(account) + "-connectionstring";
-    }
-
-    // Environment-independent Property Service secret name for a cosmos account primary key.
-    // The account's region code is retained so per-region accounts (active/active or
-    // active/passive) map to distinct secrets rather than colliding on a single name.
-    public get_key_property_name(account: string): string {
-        let util = IngredientManager.getIngredientFunction("coreutils", this.context);
-        return util.canonical_resource_name(account) + "-key";
-    }
     public async get_primary_key(name: string, rg: string | null = null) : Promise<string> {
      
         let util = IngredientManager.getIngredientFunction("coreutils", this.context)

--- a/ingredient/ingredient-property-service/src/operations/secretOperation.ts
+++ b/ingredient/ingredient-property-service/src/operations/secretOperation.ts
@@ -104,8 +104,7 @@ export class SecretOperation extends OperationBase<ISecretCreateConfiguration, I
     }
 
     private _resolveConnectionStringName(source: IConnectionStringSource): string {
-        const util = this._getSourceUtil(source.type);
-        return util.get_connectionstring_property_name(source.account);
+        return this._getCoreUtil().canonical_connectionstring_name(source.account);
     }
 
     private async _resolveConnectionStringValue(source: IConnectionStringSource): Promise<string> {
@@ -120,8 +119,7 @@ export class SecretOperation extends OperationBase<ISecretCreateConfiguration, I
     }
 
     private _resolveKeyName(source: IKeySource): string {
-        const util = this._getSourceUtil(source.type);
-        return util.get_key_property_name(source.account);
+        return this._getCoreUtil().canonical_key_name(source.account);
     }
 
     private async _resolveKeyValue(source: IKeySource): Promise<string> {
@@ -133,6 +131,14 @@ export class SecretOperation extends OperationBase<ISecretCreateConfiguration, I
             this._logger.error(`Failed to pull primary key for '${source.account}': ${error}`);
             return '';
         }
+    }
+
+    private _getCoreUtil(): any {
+        const util = IngredientManager.getIngredientFunction("coreutils", this._ctx);
+        if (!util) {
+            throw new Error(`Unable to resolve ingredient util 'coreutils' for property name derivation`);
+        }
+        return util;
     }
 
     private _getSourceUtil(type: string): any {

--- a/ingredient/ingredient-storage/src/functions.ts
+++ b/ingredient/ingredient-storage/src/functions.ts
@@ -23,22 +23,6 @@ export class StorageUtils extends BaseUtility {
         return st_profile;
     }
 
-    // Environment-independent Property Service secret name for a storage account connection
-    // string. Storage account names carry no region code, so the canonical name is simply the
-    // account name with the environment prefix stripped.
-    public get_connectionstring_property_name(account: string): string {
-        let util = IngredientManager.getIngredientFunction("coreutils", this.context)
-        return util.canonical_resource_name(account) + "-connectionstring"
-    }
-
-    // Environment-independent Property Service secret name for a storage account primary key.
-    // Storage account names carry no region code, so the canonical name is simply the account
-    // name with the environment prefix stripped.
-    public get_key_property_name(account: string): string {
-        let util = IngredientManager.getIngredientFunction("coreutils", this.context)
-        return util.canonical_resource_name(account) + "-key"
-    }
-
     public async get_primary_key(name: string, rg: string | null = null) : Promise<string> {
      
         let util = IngredientManager.getIngredientFunction("coreutils", this.context)

--- a/ingredient/ingredient-utils/src/functions.ts
+++ b/ingredient/ingredient-utils/src/functions.ts
@@ -159,6 +159,20 @@ export class CoreUtils extends BaseUtility {
         return name
     }
 
+    // Environment-independent canonical name for a resource connection string. The full naming
+    // rule (environment strip + "-connectionstring" suffix) lives here so every ingredient and
+    // recipe derives the same name for a given account.
+    public canonical_connectionstring_name(account: string): string {
+        return this.canonical_resource_name(account) + "-connectionstring"
+    }
+
+    // Environment-independent canonical name for a resource primary key. The full naming rule
+    // (environment strip + "-key" suffix) lives here so every ingredient and recipe derives the
+    // same name for a given account.
+    public canonical_key_name(account: string): string {
+        return this.canonical_resource_name(account) + "-key"
+    }
+
     private _create_resource_name(resType: string, name: string | null = null, rgn: string, suffix: string = ""): string {
         let env = this.context.Environment.environmentCode
         let pkg = this.context.Config.shortName


### PR DESCRIPTION
## Centralize canonical secret name helpers in `coreutils`

### Summary
Moves the Property Service secret-naming rule (canonical resource name + `-connectionstring` / `-key` suffix) into a single source of truth on `coreutils`. Previously this rule was duplicated in both the storage and cosmosdb ingredients, and `SecretOperation` dispatched to whichever ingredient matched the source `type` just to compute a name. Now every ingredient and recipe derives the same secret name from one place.

### Motivation
The `connectionStringFrom` / `keyFrom` shortcuts in the property-service ingredient need a deterministic, environment-independent secret name for a given account. That naming rule was copy-pasted into `ingredient-storage` and `ingredient-cosmosdb` (`get_connectionstring_property_name` / `get_key_property_name`), which:
- Risked the two implementations drifting apart.
- Forced `SecretOperation` to resolve a type-specific util (`storage` vs `cosmosdbutils`) purely to build a name, even though the naming rule is identical across resource types.

### Changes
- **`@azbake/core` (`ingredient-utils`)** — added `canonical_connectionstring_name(account)` and `canonical_key_name(account)` to `CoreUtils`. Both wrap the existing `canonical_resource_name()` (environment prefix stripped) and append the suffix.
- **`ingredient-storage`** — removed the duplicated `get_connectionstring_property_name` / `get_key_property_name` helpers.
- **`ingredient-cosmosdb`** — removed the duplicated `get_connectionstring_property_name` / `get_key_property_name` helpers.
- **`ingredient-property-service` (`SecretOperation`)** — `_resolveConnectionStringName` / `_resolveKeyName` now call the shared `coreutils` helpers instead of a type-specific util. Added a small `_getCoreUtil()` accessor that throws a clear error if `coreutils` can't be resolved.

### Behavior
No functional change to derived secret names. The canonical rule is unchanged:
- Storage: `<account-with-env-stripped>-connectionstring` / `-key` (storage names carry no region code).
- Cosmos: region code retained so per-region accounts map to distinct secrets.

Value resolution (fetching the actual connection string / key) still goes through the resource-type-specific util (`storage` / `cosmosdbutils`); only *name derivation* was centralized.

### Testing
- `npm run test` in affected ingredient packages.
- Verified `connectionStringFrom` / `keyFrom` shortcuts and the manual `canonical_connectionstring_name` / `canonical_key_name` expression forms resolve to identical secret names.

### Risk
Low — pure refactor consolidating duplicated logic behind an identical naming rule; no output name changes expected.